### PR TITLE
Add infrastructure folder with VPC module

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,28 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+module "vpc" {
+  source = "./modules/vpc"
+
+  cidr_block         = var.vpc_cidr
+  environment        = var.environment
+  availability_zones = slice(data.aws_availability_zones.available.names, 0, 3)
+  enable_nat_gateway = var.enable_nat_gateway
+
+  public_subnet_cidrs = [
+    cidrsubnet(var.vpc_cidr, 8, 1),
+    cidrsubnet(var.vpc_cidr, 8, 2),
+    cidrsubnet(var.vpc_cidr, 8, 3),
+  ]
+
+  private_subnet_cidrs = [
+    cidrsubnet(var.vpc_cidr, 8, 11),
+    cidrsubnet(var.vpc_cidr, 8, 12),
+    cidrsubnet(var.vpc_cidr, 8, 13),
+  ]
+
+  tags = {
+    Project = "mcp-infra"
+  }
+}

--- a/infra/modules/vpc/README.md
+++ b/infra/modules/vpc/README.md
@@ -1,0 +1,55 @@
+# VPC Module
+
+Creates an AWS VPC with public and private subnets across multiple availability zones, an Internet Gateway, and an optional NAT Gateway.
+
+## Usage
+
+```hcl
+module "vpc" {
+  source = "git::https://github.com/<org>/mcp-infra.git//infra/modules/vpc?ref=v1.0.0"
+
+  cidr_block         = "10.0.0.0/16"
+  environment        = "dev"
+  availability_zones = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  enable_nat_gateway = false
+
+  public_subnet_cidrs = [
+    "10.0.1.0/24",
+    "10.0.2.0/24",
+    "10.0.3.0/24",
+  ]
+
+  private_subnet_cidrs = [
+    "10.0.11.0/24",
+    "10.0.12.0/24",
+    "10.0.13.0/24",
+  ]
+
+  tags = {
+    Project = "my-project"
+  }
+}
+```
+
+## Inputs
+
+| Name                   | Type           | Default | Required | Description                                              |
+| ---------------------- | -------------- | ------- | -------- | -------------------------------------------------------- |
+| `cidr_block`           | `string`       | —      | yes      | The CIDR block for the VPC                               |
+| `environment`          | `string`       | —      | yes      | Environment name for tagging (e.g., dev, staging, prod)  |
+| `public_subnet_cidrs`  | `list(string)` | —      | yes      | CIDR blocks for public subnets (one per AZ)              |
+| `private_subnet_cidrs` | `list(string)` | —      | yes      | CIDR blocks for private subnets (one per AZ)             |
+| `availability_zones`   | `list(string)` | —      | yes      | AWS availability zones to deploy subnets into            |
+| `enable_nat_gateway`   | `bool`         | `false` | no       | Whether to create a NAT Gateway for private subnets      |
+| `tags`                 | `map(string)`  | `{}`    | no       | Additional tags to apply to all resources                |
+
+## Outputs
+
+| Name                  | Description                                       |
+| --------------------- | ------------------------------------------------- |
+| `vpc_id`              | The ID of the VPC                                 |
+| `vpc_cidr_block`      | The CIDR block of the VPC                         |
+| `public_subnet_ids`   | List of public subnet IDs                         |
+| `private_subnet_ids`  | List of private subnet IDs                        |
+| `internet_gateway_id` | The ID of the Internet Gateway                    |
+| `nat_gateway_ids`     | List of NAT Gateway IDs (empty if NAT is disabled)|

--- a/infra/modules/vpc/main.tf
+++ b/infra/modules/vpc/main.tf
@@ -1,0 +1,150 @@
+# -----------------------------------------------------------------------------
+# VPC
+# -----------------------------------------------------------------------------
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.cidr_block
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-vpc"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# Internet Gateway
+# -----------------------------------------------------------------------------
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-igw"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# Public Subnets
+# -----------------------------------------------------------------------------
+
+resource "aws_subnet" "public" {
+  count = length(var.public_subnet_cidrs)
+
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  availability_zone       = var.availability_zones[count.index]
+  map_public_ip_on_launch = true
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-public-${var.availability_zones[count.index]}"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+    Tier        = "public"
+  })
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-public-rt"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+  })
+}
+
+resource "aws_route" "public_internet" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.this.id
+}
+
+resource "aws_route_table_association" "public" {
+  count = length(var.public_subnet_cidrs)
+
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+# -----------------------------------------------------------------------------
+# Private Subnets
+# -----------------------------------------------------------------------------
+
+resource "aws_subnet" "private" {
+  count = length(var.private_subnet_cidrs)
+
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = var.private_subnet_cidrs[count.index]
+  availability_zone = var.availability_zones[count.index]
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-private-${var.availability_zones[count.index]}"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+    Tier        = "private"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# NAT Gateway (conditional)
+# -----------------------------------------------------------------------------
+
+resource "aws_eip" "nat" {
+  count  = var.enable_nat_gateway ? 1 : 0
+  domain = "vpc"
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-nat-eip"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+  })
+}
+
+resource "aws_nat_gateway" "this" {
+  count = var.enable_nat_gateway ? 1 : 0
+
+  allocation_id = aws_eip.nat[0].id
+  subnet_id     = aws_subnet.public[0].id
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-nat-gw"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+  })
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+# -----------------------------------------------------------------------------
+# Private Route Table
+# -----------------------------------------------------------------------------
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-private-rt"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+  })
+}
+
+resource "aws_route" "private_nat" {
+  count = var.enable_nat_gateway ? 1 : 0
+
+  route_table_id         = aws_route_table.private.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.this[0].id
+}
+
+resource "aws_route_table_association" "private" {
+  count = length(var.private_subnet_cidrs)
+
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}

--- a/infra/modules/vpc/outputs.tf
+++ b/infra/modules/vpc/outputs.tf
@@ -1,0 +1,29 @@
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = aws_vpc.this.id
+}
+
+output "vpc_cidr_block" {
+  description = "The CIDR block of the VPC"
+  value       = aws_vpc.this.cidr_block
+}
+
+output "public_subnet_ids" {
+  description = "List of public subnet IDs"
+  value       = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  description = "List of private subnet IDs"
+  value       = aws_subnet.private[*].id
+}
+
+output "internet_gateway_id" {
+  description = "The ID of the Internet Gateway"
+  value       = aws_internet_gateway.this.id
+}
+
+output "nat_gateway_ids" {
+  description = "List of NAT Gateway IDs (empty if NAT is disabled)"
+  value       = aws_nat_gateway.this[*].id
+}

--- a/infra/modules/vpc/variables.tf
+++ b/infra/modules/vpc/variables.tf
@@ -1,0 +1,41 @@
+variable "cidr_block" {
+  description = "The CIDR block for the VPC"
+  type        = string
+
+  validation {
+    condition     = can(cidrhost(var.cidr_block, 0))
+    error_message = "Must be a valid IPv4 CIDR block."
+  }
+}
+
+variable "environment" {
+  description = "Environment name used for tagging (e.g., dev, staging, prod)"
+  type        = string
+}
+
+variable "public_subnet_cidrs" {
+  description = "List of CIDR blocks for public subnets (one per AZ)"
+  type        = list(string)
+}
+
+variable "private_subnet_cidrs" {
+  description = "List of CIDR blocks for private subnets (one per AZ)"
+  type        = list(string)
+}
+
+variable "availability_zones" {
+  description = "List of AWS availability zones to deploy subnets into"
+  type        = list(string)
+}
+
+variable "enable_nat_gateway" {
+  description = "Whether to create a NAT Gateway for private subnet internet access"
+  type        = bool
+  default     = false
+}
+
+variable "tags" {
+  description = "Additional tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,14 @@
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = module.vpc.vpc_id
+}
+
+output "public_subnet_ids" {
+  description = "List of public subnet IDs"
+  value       = module.vpc.public_subnet_ids
+}
+
+output "private_subnet_ids" {
+  description = "List of private subnet IDs"
+  value       = module.vpc.private_subnet_ids
+}

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      ManagedBy   = "opentofu"
+      Environment = var.environment
+    }
+  }
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,33 @@
+variable "aws_region" {
+  description = "AWS region to deploy resources in"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  description = "Environment name (e.g., dev, staging, prod)"
+  type        = string
+  default     = "dev"
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "Environment must be one of: dev, staging, prod."
+  }
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+
+  validation {
+    condition     = can(cidrhost(var.vpc_cidr, 0))
+    error_message = "Must be a valid IPv4 CIDR block."
+  }
+}
+
+variable "enable_nat_gateway" {
+  description = "Whether to create a NAT Gateway for private subnets"
+  type        = bool
+  default     = false
+}

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = ">= 1.6.0, < 2.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  # Remote state backend (uncomment when ready to migrate from local state):
+  #
+  # To migrate:
+  #   1. Uncomment the backend block below
+  #   2. Run: tofu init -migrate-state
+  #   3. Confirm the migration when prompted
+  #
+  # backend "s3" {
+  #   bucket         = "your-terraform-state-bucket"
+  #   key            = "mcp-infra/terraform.tfstate"
+  #   region         = "us-east-1"
+  #   encrypt        = true
+  #   dynamodb_table = "terraform-state-lock"
+  # }
+}


### PR DESCRIPTION
## Summary

- Creates `infra/` directory with root OpenTofu configuration (providers, versions, variables, outputs)
- Adds reusable VPC module at `infra/modules/vpc/` with:
  - Public and private subnets across 3 AZs
  - Internet Gateway with public route table
  - Optional NAT Gateway (toggleable via `enable_nat_gateway`)
  - Consistent tagging (Name, Environment, ManagedBy)
  - Input validation on CIDR blocks and environment
- Includes commented-out S3 backend example for future remote state migration
- Module README with usage example, inputs table, and outputs table

## Test plan

- [ ] Review all `.tf` files against PRD Feature 3 requirements
- [ ] Verify `tofu fmt` passes on all files
- [ ] Verify `tofu validate` passes (requires `tofu init` first)
- [ ] Confirm module is consumable via git source URL pattern
- [ ] Check variable descriptions and types are complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)