### PR TITLE
Add VPC Flow Logs for network monitoring

### DIFF
--- a/infra/modules/vpc/README.md
+++ b/infra/modules/vpc/README.md
@@ -1,6 +1,6 @@
 # VPC Module
 
-Creates an AWS VPC with public and private subnets across multiple availability zones, an Internet Gateway, and an optional NAT Gateway.
+Creates an AWS VPC with public and private subnets across multiple availability zones, an Internet Gateway, an optional NAT Gateway, and optional VPC Flow Logs. Default VPC resources (security group, network ACL, route table) are managed with deny-all rules for security hardening.
 
 ## Usage
 
@@ -12,6 +12,7 @@ module "vpc" {
   environment        = "dev"
   availability_zones = ["us-east-1a", "us-east-1b", "us-east-1c"]
   enable_nat_gateway = false
+  enable_flow_logs   = true
 
   public_subnet_cidrs = [
     "10.0.1.0/24",
@@ -33,23 +34,30 @@ module "vpc" {
 
 ## Inputs
 
-| Name                   | Type           | Default | Required | Description                                              |
-| ---------------------- | -------------- | ------- | -------- | -------------------------------------------------------- |
-| `cidr_block`           | `string`       | —      | yes      | The CIDR block for the VPC                               |
-| `environment`          | `string`       | —      | yes      | Environment name for tagging (e.g., dev, staging, prod)  |
-| `public_subnet_cidrs`  | `list(string)` | —      | yes      | CIDR blocks for public subnets (one per AZ)              |
-| `private_subnet_cidrs` | `list(string)` | —      | yes      | CIDR blocks for private subnets (one per AZ)             |
-| `availability_zones`   | `list(string)` | —      | yes      | AWS availability zones to deploy subnets into            |
-| `enable_nat_gateway`   | `bool`         | `false` | no       | Whether to create a NAT Gateway for private subnets      |
-| `tags`                 | `map(string)`  | `{}`    | no       | Additional tags to apply to all resources                |
+| Name                      | Type           | Default | Required | Description                                              |
+| ------------------------- | -------------- | ------- | -------- | -------------------------------------------------------- |
+| `cidr_block`              | `string`       | —       | yes      | The CIDR block for the VPC                               |
+| `environment`             | `string`       | —       | yes      | Environment name for tagging (dev, staging, prod)        |
+| `public_subnet_cidrs`     | `list(string)` | —       | yes      | CIDR blocks for public subnets (one per AZ)              |
+| `private_subnet_cidrs`    | `list(string)` | —       | yes      | CIDR blocks for private subnets (one per AZ)             |
+| `availability_zones`      | `list(string)` | —       | yes      | AWS availability zones to deploy subnets into            |
+| `enable_nat_gateway`      | `bool`         | `false` | no       | Whether to create a NAT Gateway for private subnets      |
+| `enable_flow_logs`        | `bool`         | `true`  | no       | Whether to enable VPC Flow Logs                          |
+| `flow_log_retention_days` | `number`       | `30`    | no       | Days to retain flow logs in CloudWatch                   |
+| `tags`                    | `map(string)`  | `{}`    | no       | Additional tags to apply to all resources                |
 
 ## Outputs
 
-| Name                  | Description                                       |
-| --------------------- | ------------------------------------------------- |
-| `vpc_id`              | The ID of the VPC                                 |
-| `vpc_cidr_block`      | The CIDR block of the VPC                         |
-| `public_subnet_ids`   | List of public subnet IDs                         |
-| `private_subnet_ids`  | List of private subnet IDs                        |
-| `internet_gateway_id` | The ID of the Internet Gateway                    |
-| `nat_gateway_ids`     | List of NAT Gateway IDs (empty if NAT is disabled)|
+| Name                        | Description                                        |
+| --------------------------- | -------------------------------------------------- |
+| `vpc_id`                    | The ID of the VPC                                  |
+| `vpc_cidr_block`            | The CIDR block of the VPC                          |
+| `public_subnet_ids`         | List of public subnet IDs                          |
+| `private_subnet_ids`        | List of private subnet IDs                         |
+| `internet_gateway_id`       | The ID of the Internet Gateway                     |
+| `nat_gateway_ids`           | List of NAT Gateway IDs (empty if NAT is disabled) |
+| `public_route_table_id`     | The ID of the public route table                   |
+| `private_route_table_id`    | The ID of the private route table                  |
+| `default_security_group_id` | The ID of the default security group (deny-all)    |
+| `flow_log_id`               | The ID of the VPC Flow Log (null if disabled)      |
+| `flow_log_group_name`       | CloudWatch Log Group name for flow logs            |

--- a/infra/modules/vpc/main.tf
+++ b/infra/modules/vpc/main.tf
@@ -182,3 +182,81 @@ resource "aws_route_table_association" "private" {
   subnet_id      = aws_subnet.private[count.index].id
   route_table_id = aws_route_table.private.id
 }
+
+# -----------------------------------------------------------------------------
+# VPC Flow Logs
+# -----------------------------------------------------------------------------
+
+resource "aws_flow_log" "this" {
+  count = var.enable_flow_logs ? 1 : 0
+
+  vpc_id               = aws_vpc.this.id
+  traffic_type         = "ALL"
+  log_destination_type = "cloud-watch-logs"
+  log_destination      = aws_cloudwatch_log_group.flow_logs[0].arn
+  iam_role_arn         = aws_iam_role.flow_logs[0].arn
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-vpc-flow-logs"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+  })
+}
+
+resource "aws_cloudwatch_log_group" "flow_logs" {
+  count = var.enable_flow_logs ? 1 : 0
+
+  name              = "/aws/vpc/${var.environment}-flow-logs"
+  retention_in_days = var.flow_log_retention_days
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-vpc-flow-logs"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+  })
+}
+
+resource "aws_iam_role" "flow_logs" {
+  count = var.enable_flow_logs ? 1 : 0
+
+  name = "${var.environment}-vpc-flow-logs-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "vpc-flow-logs.amazonaws.com"
+      }
+    }]
+  })
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-vpc-flow-logs-role"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+  })
+}
+
+resource "aws_iam_role_policy" "flow_logs" {
+  count = var.enable_flow_logs ? 1 : 0
+
+  name = "${var.environment}-vpc-flow-logs-policy"
+  role = aws_iam_role.flow_logs[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams"
+      ]
+      Effect   = "Allow"
+      Resource = "*"
+    }]
+  })
+}

--- a/infra/modules/vpc/outputs.tf
+++ b/infra/modules/vpc/outputs.tf
@@ -42,3 +42,13 @@ output "default_security_group_id" {
   description = "The ID of the default security group (deny-all)"
   value       = aws_default_security_group.this.id
 }
+
+output "flow_log_id" {
+  description = "The ID of the VPC Flow Log (null if flow logs are disabled)"
+  value       = try(aws_flow_log.this[0].id, null)
+}
+
+output "flow_log_group_name" {
+  description = "The CloudWatch Log Group name for VPC Flow Logs"
+  value       = try(aws_cloudwatch_log_group.flow_logs[0].name, null)
+}

--- a/infra/modules/vpc/variables.tf
+++ b/infra/modules/vpc/variables.tf
@@ -54,6 +54,23 @@ variable "enable_nat_gateway" {
   default     = false
 }
 
+variable "enable_flow_logs" {
+  description = "Whether to enable VPC Flow Logs for network traffic monitoring"
+  type        = bool
+  default     = true
+}
+
+variable "flow_log_retention_days" {
+  description = "Number of days to retain VPC Flow Logs in CloudWatch"
+  type        = number
+  default     = 30
+
+  validation {
+    condition     = contains([1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653], var.flow_log_retention_days)
+    error_message = "Retention days must be a valid CloudWatch Logs retention value."
+  }
+}
+
 variable "tags" {
   description = "Additional tags to apply to all resources"
   type        = map(string)


### PR DESCRIPTION
## Summary
- Add VPC Flow Logs to VPC module (CloudWatch Logs destination)
- Create IAM role and policy for flow log delivery
- Add `enable_flow_logs` variable (default: `true` — secure by default)
- Add `flow_log_retention_days` variable (default: `30`, validated against CloudWatch allowed values)
- Expose `flow_log_id` and `flow_log_group_name` outputs
- Update VPC module README with all inputs/outputs including hardening additions

Replaces #15 (rebased on top of #16 hardening changes). Closes #9.

## Test plan
- [ ] Verify flow log resources created when `enable_flow_logs = true`
- [ ] Verify no flow log resources when `enable_flow_logs = false`
- [ ] Confirm IAM role follows least-privilege (CloudWatch Logs actions only)
- [ ] Check retention days validation rejects invalid values

🤖 Generated with [Claude Code](https://claude.com/claude-code)