### PR TITLE
Add production-hardened API Gateway module

### DIFF
--- a/infra/modules/api_gateway/README.md
+++ b/infra/modules/api_gateway/README.md
@@ -1,0 +1,135 @@
+# API Gateway Module
+
+Creates a production-hardened AWS API Gateway v2 (HTTP API) with access logging, throttling, optional CORS, VPC Link, WAF integration, and KMS-encrypted logs.
+
+Aligned with **AWS Well-Architected Framework** Security Pillar and **FedRAMP** compliance controls.
+
+## Usage
+
+### Basic HTTP API
+
+```hcl
+module "api_gateway" {
+  source = "git::https://github.com/<org>/mcp-infra.git//infra/modules/api_gateway?ref=v1.0.0"
+
+  name        = "my-api"
+  environment = "dev"
+
+  tags = {
+    Project = "my-project"
+  }
+}
+```
+
+### Production API with WAF, CORS, and KMS Encryption
+
+```hcl
+module "api_gateway" {
+  source = "git::https://github.com/<org>/mcp-infra.git//infra/modules/api_gateway?ref=v1.0.0"
+
+  name        = "my-api"
+  description = "Production API for my-service"
+  environment = "prod"
+
+  # Throttling
+  throttling_rate_limit  = 2000
+  throttling_burst_limit = 1000
+
+  # Logging with KMS encryption
+  log_retention_days = 365
+  kms_key_arn        = module.kms.key_arn
+
+  # CORS
+  enable_cors          = true
+  cors_allowed_origins = ["https://app.example.com"]
+  cors_allowed_methods = ["GET", "POST", "PUT", "DELETE"]
+
+  # WAF
+  waf_acl_arn = aws_wafv2_web_acl.api.arn
+
+  tags = {
+    Project = "my-project"
+  }
+}
+```
+
+### With VPC Link for Private Backends
+
+```hcl
+module "api_gateway" {
+  source = "git::https://github.com/<org>/mcp-infra.git//infra/modules/api_gateway?ref=v1.0.0"
+
+  name        = "internal-api"
+  environment = "prod"
+
+  vpc_link_subnet_ids         = module.vpc.private_subnet_ids
+  vpc_link_security_group_ids = [module.security_groups.app_security_group_id]
+
+  tags = {
+    Project = "my-project"
+  }
+}
+```
+
+## Inputs
+
+| Name                            | Type           | Default                                              | Required | Description                                    |
+| ------------------------------- | -------------- | ---------------------------------------------------- | -------- | ---------------------------------------------- |
+| `name`                          | `string`       | `api`                                                | no       | API name (prefixed with environment)           |
+| `description`                   | `string`       | `""`                                                 | no       | API description                                |
+| `environment`                   | `string`       | —                                                    | yes      | Environment name (dev, staging, prod)          |
+| `enable_auto_deploy`            | `bool`         | `true`                                               | no       | Auto-deploy changes to default stage           |
+| `throttling_rate_limit`         | `number`       | `1000`                                               | no       | Requests/second rate limit (1–10000)           |
+| `throttling_burst_limit`        | `number`       | `500`                                                | no       | Burst capacity (1–5000)                        |
+| `enable_access_logging`         | `bool`         | `true`                                               | no       | Enable CloudWatch access logging               |
+| `log_retention_days`            | `number`       | `90`                                                 | no       | Log retention in days                          |
+| `kms_key_arn`                   | `string`       | `null`                                               | no       | KMS key for log encryption (null = AWS default)|
+| `enable_cors`                   | `bool`         | `false`                                              | no       | Enable CORS                                    |
+| `cors_allowed_origins`          | `list(string)` | `[]`                                                 | no       | Allowed CORS origins                           |
+| `cors_allowed_methods`          | `list(string)` | `["GET","POST","PUT","DELETE","OPTIONS"]`            | no       | Allowed CORS methods                           |
+| `cors_allowed_headers`          | `list(string)` | `["Content-Type","Authorization","X-Amz-Date",...] ` | no       | Allowed CORS headers                           |
+| `cors_expose_headers`           | `list(string)` | `[]`                                                 | no       | CORS exposed headers                           |
+| `cors_max_age`                  | `number`       | `86400`                                              | no       | CORS preflight cache (seconds)                 |
+| `cors_allow_credentials`        | `bool`         | `false`                                              | no       | Allow credentials in CORS                      |
+| `vpc_link_subnet_ids`           | `list(string)` | `[]`                                                 | no       | Subnet IDs for VPC Link (empty = no link)      |
+| `vpc_link_security_group_ids`   | `list(string)` | `[]`                                                 | no       | Security groups for VPC Link                   |
+| `waf_acl_arn`                   | `string`       | `null`                                               | no       | WAFv2 ACL ARN (null = no WAF)                  |
+| `tags`                          | `map(string)`  | `{}`                                                 | no       | Additional tags                                |
+
+## Outputs
+
+| Name                       | Description                                         |
+| -------------------------- | --------------------------------------------------- |
+| `api_id`                   | The ID of the API Gateway                           |
+| `api_arn`                  | The ARN of the API Gateway                          |
+| `api_endpoint`             | The default endpoint URL                            |
+| `stage_id`                 | The ID of the default stage                         |
+| `stage_invoke_url`         | The invocation URL of the default stage             |
+| `cloudwatch_log_group_name`| Log group name (null if logging disabled)           |
+| `cloudwatch_log_group_arn` | Log group ARN (null if logging disabled)            |
+| `vpc_link_id`              | VPC Link ID (null if no VPC Link)                   |
+| `execution_role_arn`       | IAM role ARN for logging (null if logging disabled) |
+
+## Security Features
+
+- **Access logging**: CloudWatch Logs enabled by default with 90-day retention
+- **Log encryption**: Optional customer-managed KMS key (FedRAMP AU-9, SC-28)
+- **Throttling**: Configurable rate and burst limits to prevent abuse (SEC-06)
+- **Least-privilege IAM**: Logging role scoped to specific log group ARN (AC-6)
+- **WAF integration**: Optional WAFv2 association for OWASP Top 10 protection (SC-7)
+- **VPC Link**: Optional private backend connectivity (SC-7)
+- **CORS**: Restrictive by default, configurable origins and methods
+- **Auto-deploy**: Changes deploy automatically to reduce manual intervention risk
+
+## FedRAMP Controls
+
+| Control | Requirement                          | Implementation                              |
+| ------- | ------------------------------------ | ------------------------------------------- |
+| AC-6    | Least privilege                      | IAM role scoped to log group ARN            |
+| AU-2    | Audit events                         | CloudWatch access logs enabled by default   |
+| AU-3    | Content of audit records             | Request/response metadata in access logs    |
+| AU-9    | Protection of audit information      | KMS encryption on log group                 |
+| SC-7    | Boundary protection                  | VPC Link + WAF integration                  |
+| SC-8    | Transmission confidentiality         | HTTPS-only API endpoint (API Gateway v2)    |
+| SC-28   | Protection of information at rest    | KMS encryption for log data                 |
+| SI-4    | System monitoring                    | Access logging + throttling metrics         |

--- a/infra/modules/api_gateway/main.tf
+++ b/infra/modules/api_gateway/main.tf
@@ -1,0 +1,157 @@
+# -----------------------------------------------------------------------------
+# API Gateway v2 (HTTP API)
+# -----------------------------------------------------------------------------
+
+resource "aws_apigatewayv2_api" "this" {
+  name          = "${var.environment}-${var.name}"
+  description   = var.description
+  protocol_type = "HTTP"
+
+  dynamic "cors_configuration" {
+    for_each = var.enable_cors ? [1] : []
+    content {
+      allow_origins     = var.cors_allowed_origins
+      allow_methods     = var.cors_allowed_methods
+      allow_headers     = var.cors_allowed_headers
+      expose_headers    = var.cors_expose_headers
+      max_age           = var.cors_max_age
+      allow_credentials = var.cors_allow_credentials
+    }
+  }
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-${var.name}"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# Default Stage with Access Logging and Throttling
+# -----------------------------------------------------------------------------
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.this.id
+  name        = "$default"
+  auto_deploy = var.enable_auto_deploy
+
+  dynamic "access_log_settings" {
+    for_each = var.enable_access_logging ? [1] : []
+    content {
+      destination_arn = aws_cloudwatch_log_group.api[0].arn
+    }
+  }
+
+  default_route_settings {
+    throttling_rate_limit  = var.throttling_rate_limit
+    throttling_burst_limit = var.throttling_burst_limit
+  }
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-${var.name}-default-stage"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# CloudWatch Log Group for Access Logs (FedRAMP AU-2, AU-3, AU-9)
+# -----------------------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "api" {
+  count = var.enable_access_logging ? 1 : 0
+
+  name              = "/aws/apigateway/${var.environment}-${var.name}"
+  retention_in_days = var.log_retention_days
+  kms_key_id        = var.kms_key_arn
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-${var.name}-access-logs"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# IAM Role for CloudWatch Logging (least-privilege, scoped to log group)
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "api_logging" {
+  count = var.enable_access_logging ? 1 : 0
+
+  name = "${var.environment}-${var.name}-apigw-logging-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "apigateway.amazonaws.com"
+      }
+    }]
+  })
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-${var.name}-apigw-logging-role"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+  })
+}
+
+# Scoped to the specific log group ARN — least-privilege per CLAUDE.md
+resource "aws_iam_role_policy" "api_logging" {
+  count = var.enable_access_logging ? 1 : 0
+
+  name = "${var.environment}-${var.name}-apigw-logging-policy"
+  role = aws_iam_role.api_logging[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogStreams"
+      ]
+      Effect   = "Allow"
+      Resource = "${aws_cloudwatch_log_group.api[0].arn}:*"
+    }]
+  })
+}
+
+# Set the CloudWatch role ARN at the account level for API Gateway logging
+resource "aws_api_gateway_account" "this" {
+  count = var.enable_access_logging ? 1 : 0
+
+  cloudwatch_role_arn = aws_iam_role.api_logging[0].arn
+}
+
+# -----------------------------------------------------------------------------
+# VPC Link (conditional — for private backend integration, FedRAMP SC-7)
+# -----------------------------------------------------------------------------
+
+resource "aws_apigatewayv2_vpc_link" "this" {
+  count = length(var.vpc_link_subnet_ids) > 0 ? 1 : 0
+
+  name               = "${var.environment}-${var.name}-vpc-link"
+  subnet_ids         = var.vpc_link_subnet_ids
+  security_group_ids = var.vpc_link_security_group_ids
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-${var.name}-vpc-link"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# WAF Association (conditional — Layer 7 protection, FedRAMP SC-7)
+# -----------------------------------------------------------------------------
+
+resource "aws_wafv2_web_acl_association" "this" {
+  count = var.waf_acl_arn != null ? 1 : 0
+
+  resource_arn = aws_apigatewayv2_stage.default.arn
+  web_acl_arn  = var.waf_acl_arn
+}

--- a/infra/modules/api_gateway/outputs.tf
+++ b/infra/modules/api_gateway/outputs.tf
@@ -1,0 +1,44 @@
+output "api_id" {
+  description = "The ID of the API Gateway"
+  value       = aws_apigatewayv2_api.this.id
+}
+
+output "api_arn" {
+  description = "The ARN of the API Gateway"
+  value       = aws_apigatewayv2_api.this.arn
+}
+
+output "api_endpoint" {
+  description = "The default endpoint URL of the API"
+  value       = aws_apigatewayv2_api.this.api_endpoint
+}
+
+output "stage_id" {
+  description = "The ID of the default stage"
+  value       = aws_apigatewayv2_stage.default.id
+}
+
+output "stage_invoke_url" {
+  description = "The invocation URL of the default stage"
+  value       = aws_apigatewayv2_stage.default.invoke_url
+}
+
+output "cloudwatch_log_group_name" {
+  description = "The CloudWatch Log Group name for API access logs (null if logging disabled)"
+  value       = try(aws_cloudwatch_log_group.api[0].name, null)
+}
+
+output "cloudwatch_log_group_arn" {
+  description = "The CloudWatch Log Group ARN for API access logs (null if logging disabled)"
+  value       = try(aws_cloudwatch_log_group.api[0].arn, null)
+}
+
+output "vpc_link_id" {
+  description = "The ID of the VPC Link (null if no VPC Link created)"
+  value       = try(aws_apigatewayv2_vpc_link.this[0].id, null)
+}
+
+output "execution_role_arn" {
+  description = "The ARN of the IAM role used for CloudWatch logging (null if logging disabled)"
+  value       = try(aws_iam_role.api_logging[0].arn, null)
+}

--- a/infra/modules/api_gateway/variables.tf
+++ b/infra/modules/api_gateway/variables.tf
@@ -1,0 +1,167 @@
+variable "name" {
+  description = "Name for the API Gateway (will be prefixed with environment)"
+  type        = string
+  default     = "api"
+
+  validation {
+    condition     = length(var.name) >= 1 && length(var.name) <= 40
+    error_message = "Name must be between 1 and 40 characters."
+  }
+}
+
+variable "description" {
+  description = "Description of the API Gateway"
+  type        = string
+  default     = ""
+}
+
+variable "environment" {
+  description = "Environment name used for tagging (e.g., dev, staging, prod)"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "Environment must be one of: dev, staging, prod."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Stage and Deployment
+# -----------------------------------------------------------------------------
+
+variable "enable_auto_deploy" {
+  description = "Whether changes are automatically deployed to the default stage"
+  type        = bool
+  default     = true
+}
+
+variable "throttling_rate_limit" {
+  description = "Requests per second rate limit for the default stage"
+  type        = number
+  default     = 1000
+
+  validation {
+    condition     = var.throttling_rate_limit >= 1 && var.throttling_rate_limit <= 10000
+    error_message = "Throttling rate limit must be between 1 and 10000 requests per second."
+  }
+}
+
+variable "throttling_burst_limit" {
+  description = "Burst capacity for the default stage"
+  type        = number
+  default     = 500
+
+  validation {
+    condition     = var.throttling_burst_limit >= 1 && var.throttling_burst_limit <= 5000
+    error_message = "Throttling burst limit must be between 1 and 5000."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Access Logging (FedRAMP AU-2, AU-3, AU-9)
+# -----------------------------------------------------------------------------
+
+variable "enable_access_logging" {
+  description = "Whether to enable CloudWatch access logging for the API"
+  type        = bool
+  default     = true
+}
+
+variable "log_retention_days" {
+  description = "Number of days to retain API access logs in CloudWatch"
+  type        = number
+  default     = 90
+
+  validation {
+    condition     = contains([1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653], var.log_retention_days)
+    error_message = "Retention days must be a valid CloudWatch Logs retention value."
+  }
+}
+
+variable "kms_key_arn" {
+  description = "ARN of a KMS key for encrypting CloudWatch Logs. If null, uses AWS-managed encryption."
+  type        = string
+  default     = null
+}
+
+# -----------------------------------------------------------------------------
+# CORS Configuration
+# -----------------------------------------------------------------------------
+
+variable "enable_cors" {
+  description = "Whether to enable CORS on the API"
+  type        = bool
+  default     = false
+}
+
+variable "cors_allowed_origins" {
+  description = "List of allowed origins for CORS"
+  type        = list(string)
+  default     = []
+}
+
+variable "cors_allowed_methods" {
+  description = "List of allowed HTTP methods for CORS"
+  type        = list(string)
+  default     = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
+}
+
+variable "cors_allowed_headers" {
+  description = "List of allowed headers for CORS"
+  type        = list(string)
+  default     = ["Content-Type", "Authorization", "X-Amz-Date", "X-Api-Key"]
+}
+
+variable "cors_expose_headers" {
+  description = "List of headers to expose in CORS responses"
+  type        = list(string)
+  default     = []
+}
+
+variable "cors_max_age" {
+  description = "Maximum age in seconds for CORS preflight cache"
+  type        = number
+  default     = 86400
+}
+
+variable "cors_allow_credentials" {
+  description = "Whether to allow credentials in CORS requests"
+  type        = bool
+  default     = false
+}
+
+# -----------------------------------------------------------------------------
+# VPC Link (FedRAMP SC-7 — boundary protection)
+# -----------------------------------------------------------------------------
+
+variable "vpc_link_subnet_ids" {
+  description = "List of subnet IDs for the VPC Link. If empty, no VPC Link is created."
+  type        = list(string)
+  default     = []
+}
+
+variable "vpc_link_security_group_ids" {
+  description = "List of security group IDs for the VPC Link"
+  type        = list(string)
+  default     = []
+}
+
+# -----------------------------------------------------------------------------
+# WAF (FedRAMP SC-7 — Layer 7 protection)
+# -----------------------------------------------------------------------------
+
+variable "waf_acl_arn" {
+  description = "ARN of the WAFv2 web ACL to associate with the API stage. If null, no WAF is attached."
+  type        = string
+  default     = null
+}
+
+# -----------------------------------------------------------------------------
+# Tags
+# -----------------------------------------------------------------------------
+
+variable "tags" {
+  description = "Additional tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary
- New module at `infra/modules/api_gateway/` for AWS API Gateway v2 (HTTP API)
- CloudWatch access logging with optional KMS encryption (FedRAMP AU-9, SC-28)
- Configurable throttling (rate + burst limits) per stage
- Least-privilege IAM execution role scoped to specific log group ARN (AC-6)
- Optional VPC Link for private backend integration (SC-7)
- Optional WAFv2 web ACL association for Layer 7 protection
- Configurable CORS with restrictive defaults
- Input validations on throttling, retention, and name length

Closes #25

## Test plan
- [ ] Verify `tofu validate` passes
- [ ] Confirm logging role IAM policy is scoped to log group ARN (not `*`)
- [ ] Check VPC Link only created when `vpc_link_subnet_ids` is non-empty
- [ ] Verify WAF association only created when `waf_acl_arn` is set
- [ ] Confirm CORS block only rendered when `enable_cors = true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)