### PR TITLE
Add CloudWatch Alarms module

### DIFF
--- a/infra/modules/cloudwatch_alarms/README.md
+++ b/infra/modules/cloudwatch_alarms/README.md
@@ -1,0 +1,121 @@
+# CloudWatch Alarms Module
+
+Provides configurable CloudWatch metric alarms for FedRAMP SI-4 continuous monitoring. Supports ALB, API Gateway, and VPC Flow Logs metrics with SNS notifications and optional auto-remediation via Lambda.
+
+## Usage
+
+### Basic ALB Monitoring
+
+```hcl
+module "alarms" {
+  source = "git::https://github.com/<org>/mcp-infra.git//infra/modules/cloudwatch_alarms?ref=v1.0.0"
+
+  name        = "my-app"
+  environment = "prod"
+
+  # ALB alarms
+  enable_alb_5xx_alarm    = true
+  enable_alb_unhealthy_alarm = true
+  alb_arn_suffix             = module.alb.arn_suffix
+  alb_target_group_arn_suffix = module.alb.target_group_arn_suffix
+
+  tags = {
+    Project = "my-project"
+  }
+}
+```
+
+### Full Stack Monitoring
+
+```hcl
+module "alarms" {
+  source = "git::https://github.com/<org>/mcp-infra.git//infra/modules/cloudwatch_alarms?ref=v1.0.0"
+
+  name        = "my-app"
+  environment = "prod"
+  kms_key_arn = module.kms.key_arn
+
+  # ALB alarms
+  enable_alb_5xx_alarm           = true
+  enable_alb_unhealthy_alarm     = true
+  alb_arn_suffix                 = module.alb.arn_suffix
+  alb_target_group_arn_suffix    = module.alb.target_group_arn_suffix
+
+  # API Gateway alarms
+  enable_apigw_5xx_alarm     = true
+  enable_apigw_4xx_alarm     = true
+  enable_apigw_latency_alarm = true
+  apigw_api_id               = module.apigw.api_id
+
+  # VPC Flow Logs alarm
+  enable_vpc_rejected_alarm   = true
+  vpc_flow_log_group_name     = module.vpc.flow_log_group_name
+
+  # Auto-remediation
+  remediation_lambda_arn = module.remediation.lambda_arn
+
+  tags = {
+    Project = "my-project"
+  }
+}
+```
+
+## Inputs
+
+| Name | Type | Default | Required | Description |
+| ---- | ---- | ------- | -------- | ----------- |
+| `name` | `string` | `"infra"` | no | Name prefix for alarm resources |
+| `environment` | `string` | -- | yes | Environment name (dev, staging, prod) |
+| `kms_key_arn` | `string` | `null` | no | KMS key ARN for SNS topic encryption |
+| `remediation_lambda_arn` | `string` | `""` | no | Lambda ARN for auto-remediation actions |
+| `tags` | `map(string)` | `{}` | no | Additional tags for all resources |
+| `alb_arn_suffix` | `string` | `""` | no | ALB ARN suffix (required when ALB alarms enabled) |
+| `alb_target_group_arn_suffix` | `string` | `""` | no | ALB target group ARN suffix (required when unhealthy alarm enabled) |
+| `enable_alb_5xx_alarm` | `bool` | `false` | no | Enable ALB 5xx error alarm |
+| `alb_5xx_threshold` | `number` | `50` | no | ALB 5xx error count threshold |
+| `alb_5xx_period` | `number` | `300` | no | ALB 5xx evaluation period (seconds) |
+| `alb_5xx_evaluation_periods` | `number` | `3` | no | ALB 5xx number of evaluation periods |
+| `enable_alb_unhealthy_alarm` | `bool` | `false` | no | Enable ALB unhealthy targets alarm |
+| `alb_unhealthy_threshold` | `number` | `0` | no | ALB unhealthy target count threshold |
+| `alb_unhealthy_period` | `number` | `300` | no | ALB unhealthy evaluation period (seconds) |
+| `alb_unhealthy_evaluation_periods` | `number` | `3` | no | ALB unhealthy number of evaluation periods |
+| `apigw_api_id` | `string` | `""` | no | API Gateway API ID (required when API GW alarms enabled) |
+| `enable_apigw_5xx_alarm` | `bool` | `false` | no | Enable API Gateway 5xx error alarm |
+| `apigw_5xx_threshold` | `number` | `50` | no | API Gateway 5xx error count threshold |
+| `apigw_5xx_period` | `number` | `300` | no | API Gateway 5xx evaluation period (seconds) |
+| `apigw_5xx_evaluation_periods` | `number` | `3` | no | API Gateway 5xx number of evaluation periods |
+| `enable_apigw_4xx_alarm` | `bool` | `false` | no | Enable API Gateway 4xx error alarm |
+| `apigw_4xx_threshold` | `number` | `200` | no | API Gateway 4xx error count threshold |
+| `apigw_4xx_period` | `number` | `300` | no | API Gateway 4xx evaluation period (seconds) |
+| `apigw_4xx_evaluation_periods` | `number` | `3` | no | API Gateway 4xx number of evaluation periods |
+| `enable_apigw_latency_alarm` | `bool` | `false` | no | Enable API Gateway latency alarm |
+| `apigw_latency_threshold` | `number` | `5000` | no | API Gateway p99 latency threshold (ms) |
+| `apigw_latency_period` | `number` | `300` | no | API Gateway latency evaluation period (seconds) |
+| `apigw_latency_evaluation_periods` | `number` | `3` | no | API Gateway latency number of evaluation periods |
+| `vpc_flow_log_group_name` | `string` | `""` | no | CloudWatch Log Group name for VPC Flow Logs |
+| `enable_vpc_rejected_alarm` | `bool` | `false` | no | Enable VPC rejected packets alarm |
+| `vpc_rejected_threshold` | `number` | `1000` | no | VPC rejected packet count threshold |
+| `vpc_rejected_period` | `number` | `300` | no | VPC rejected packets evaluation period (seconds) |
+| `vpc_rejected_evaluation_periods` | `number` | `3` | no | VPC rejected packets number of evaluation periods |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| `sns_topic_arn` | The ARN of the SNS alarm notification topic |
+| `sns_topic_name` | The name of the SNS alarm notification topic |
+| `alb_5xx_alarm_arn` | The ARN of the ALB 5xx error alarm (null if disabled) |
+| `alb_unhealthy_alarm_arn` | The ARN of the ALB unhealthy targets alarm (null if disabled) |
+| `apigw_5xx_alarm_arn` | The ARN of the API Gateway 5xx alarm (null if disabled) |
+| `apigw_4xx_alarm_arn` | The ARN of the API Gateway 4xx alarm (null if disabled) |
+| `apigw_latency_alarm_arn` | The ARN of the API Gateway latency alarm (null if disabled) |
+| `vpc_rejected_alarm_arn` | The ARN of the VPC rejected packets alarm (null if disabled) |
+
+## FedRAMP Controls
+
+| Control | Title | How This Module Helps |
+| ------- | ----- | --------------------- |
+| SI-4 | System Monitoring | Provides continuous metric monitoring with configurable thresholds for ALB, API Gateway, and VPC traffic |
+| SI-5 | Security Alerts, Advisories, and Directives | SNS topic delivers real-time alarm notifications to subscribed operators |
+| IR-4 | Incident Handling | Optional auto-remediation Lambda integration enables automated incident response |
+| AU-6 | Audit Record Review, Analysis, and Reporting | VPC Flow Logs rejected packets alarm supports audit log anomaly detection |

--- a/infra/modules/cloudwatch_alarms/main.tf
+++ b/infra/modules/cloudwatch_alarms/main.tf
@@ -1,0 +1,245 @@
+# -----------------------------------------------------------------------------
+# SNS Topic for Alarm Notifications
+# -----------------------------------------------------------------------------
+
+resource "aws_sns_topic" "alarms" {
+  name              = "${var.environment}-${var.name}-alarms"
+  kms_master_key_id = var.kms_key_arn
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-${var.name}-alarms"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# ALB 5xx Error Rate Alarm
+# -----------------------------------------------------------------------------
+
+resource "aws_cloudwatch_metric_alarm" "alb_5xx" {
+  count = var.enable_alb_5xx_alarm ? 1 : 0
+
+  alarm_name          = "${var.environment}-${var.name}-alb-5xx"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = var.alb_5xx_evaluation_periods
+  metric_name         = "HTTPCode_ELB_5XX_Count"
+  namespace           = "AWS/ApplicationELB"
+  period              = var.alb_5xx_period
+  statistic           = "Sum"
+  threshold           = var.alb_5xx_threshold
+  alarm_description   = "ALB 5xx error count exceeded threshold (FedRAMP SI-4)"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    LoadBalancer = var.alb_arn_suffix
+  }
+
+  alarm_actions = compact([
+    aws_sns_topic.alarms.arn,
+    var.remediation_lambda_arn,
+  ])
+
+  ok_actions = [aws_sns_topic.alarms.arn]
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-${var.name}-alb-5xx"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+    FedRAMP     = "SI-4"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# ALB Unhealthy Targets Alarm
+# -----------------------------------------------------------------------------
+
+resource "aws_cloudwatch_metric_alarm" "alb_unhealthy_targets" {
+  count = var.enable_alb_unhealthy_alarm ? 1 : 0
+
+  alarm_name          = "${var.environment}-${var.name}-alb-unhealthy-targets"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = var.alb_unhealthy_evaluation_periods
+  metric_name         = "UnHealthyHostCount"
+  namespace           = "AWS/ApplicationELB"
+  period              = var.alb_unhealthy_period
+  statistic           = "Maximum"
+  threshold           = var.alb_unhealthy_threshold
+  alarm_description   = "ALB unhealthy target count exceeded threshold (FedRAMP SI-4)"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    TargetGroup  = var.alb_target_group_arn_suffix
+    LoadBalancer = var.alb_arn_suffix
+  }
+
+  alarm_actions = compact([
+    aws_sns_topic.alarms.arn,
+    var.remediation_lambda_arn,
+  ])
+
+  ok_actions = [aws_sns_topic.alarms.arn]
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-${var.name}-alb-unhealthy-targets"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+    FedRAMP     = "SI-4"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# API Gateway 5xx Error Rate Alarm
+# -----------------------------------------------------------------------------
+
+resource "aws_cloudwatch_metric_alarm" "apigw_5xx" {
+  count = var.enable_apigw_5xx_alarm ? 1 : 0
+
+  alarm_name          = "${var.environment}-${var.name}-apigw-5xx"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = var.apigw_5xx_evaluation_periods
+  metric_name         = "5xx"
+  namespace           = "AWS/ApiGateway"
+  period              = var.apigw_5xx_period
+  statistic           = "Sum"
+  threshold           = var.apigw_5xx_threshold
+  alarm_description   = "API Gateway 5xx error count exceeded threshold (FedRAMP SI-4)"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    ApiId = var.apigw_api_id
+  }
+
+  alarm_actions = compact([
+    aws_sns_topic.alarms.arn,
+    var.remediation_lambda_arn,
+  ])
+
+  ok_actions = [aws_sns_topic.alarms.arn]
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-${var.name}-apigw-5xx"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+    FedRAMP     = "SI-4"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# API Gateway 4xx Error Rate Alarm
+# -----------------------------------------------------------------------------
+
+resource "aws_cloudwatch_metric_alarm" "apigw_4xx" {
+  count = var.enable_apigw_4xx_alarm ? 1 : 0
+
+  alarm_name          = "${var.environment}-${var.name}-apigw-4xx"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = var.apigw_4xx_evaluation_periods
+  metric_name         = "4xx"
+  namespace           = "AWS/ApiGateway"
+  period              = var.apigw_4xx_period
+  statistic           = "Sum"
+  threshold           = var.apigw_4xx_threshold
+  alarm_description   = "API Gateway 4xx error count exceeded threshold (FedRAMP SI-4)"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    ApiId = var.apigw_api_id
+  }
+
+  alarm_actions = compact([
+    aws_sns_topic.alarms.arn,
+    var.remediation_lambda_arn,
+  ])
+
+  ok_actions = [aws_sns_topic.alarms.arn]
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-${var.name}-apigw-4xx"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+    FedRAMP     = "SI-4"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# API Gateway Latency Alarm
+# -----------------------------------------------------------------------------
+
+resource "aws_cloudwatch_metric_alarm" "apigw_latency" {
+  count = var.enable_apigw_latency_alarm ? 1 : 0
+
+  alarm_name          = "${var.environment}-${var.name}-apigw-latency"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = var.apigw_latency_evaluation_periods
+  metric_name         = "Latency"
+  namespace           = "AWS/ApiGateway"
+  period              = var.apigw_latency_period
+  statistic           = "p99"
+  threshold           = var.apigw_latency_threshold
+  alarm_description   = "API Gateway p99 latency exceeded threshold (FedRAMP SI-4)"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    ApiId = var.apigw_api_id
+  }
+
+  alarm_actions = compact([
+    aws_sns_topic.alarms.arn,
+    var.remediation_lambda_arn,
+  ])
+
+  ok_actions = [aws_sns_topic.alarms.arn]
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-${var.name}-apigw-latency"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+    FedRAMP     = "SI-4"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# VPC Flow Logs Rejected Packets Alarm
+# -----------------------------------------------------------------------------
+
+resource "aws_cloudwatch_metric_alarm" "vpc_rejected_packets" {
+  count = var.enable_vpc_rejected_alarm ? 1 : 0
+
+  alarm_name          = "${var.environment}-${var.name}-vpc-rejected-packets"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = var.vpc_rejected_evaluation_periods
+  threshold           = var.vpc_rejected_threshold
+  alarm_description   = "VPC Flow Logs rejected packet count exceeded threshold (FedRAMP SI-4)"
+  treat_missing_data  = "notBreaching"
+
+  metric_query {
+    id          = "rejected"
+    return_data = true
+
+    metric {
+      metric_name = "RejectedPackets"
+      namespace   = "VPCFlowLogs"
+      period      = var.vpc_rejected_period
+      stat        = "Sum"
+
+      dimensions = {
+        LogGroupName = var.vpc_flow_log_group_name
+      }
+    }
+  }
+
+  alarm_actions = compact([
+    aws_sns_topic.alarms.arn,
+    var.remediation_lambda_arn,
+  ])
+
+  ok_actions = [aws_sns_topic.alarms.arn]
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-${var.name}-vpc-rejected-packets"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+    FedRAMP     = "SI-4"
+  })
+}

--- a/infra/modules/cloudwatch_alarms/outputs.tf
+++ b/infra/modules/cloudwatch_alarms/outputs.tf
@@ -1,0 +1,39 @@
+output "sns_topic_arn" {
+  description = "The ARN of the SNS alarm notification topic"
+  value       = aws_sns_topic.alarms.arn
+}
+
+output "sns_topic_name" {
+  description = "The name of the SNS alarm notification topic"
+  value       = aws_sns_topic.alarms.name
+}
+
+output "alb_5xx_alarm_arn" {
+  description = "The ARN of the ALB 5xx error alarm (null if disabled)"
+  value       = try(aws_cloudwatch_metric_alarm.alb_5xx[0].arn, null)
+}
+
+output "alb_unhealthy_alarm_arn" {
+  description = "The ARN of the ALB unhealthy targets alarm (null if disabled)"
+  value       = try(aws_cloudwatch_metric_alarm.alb_unhealthy_targets[0].arn, null)
+}
+
+output "apigw_5xx_alarm_arn" {
+  description = "The ARN of the API Gateway 5xx alarm (null if disabled)"
+  value       = try(aws_cloudwatch_metric_alarm.apigw_5xx[0].arn, null)
+}
+
+output "apigw_4xx_alarm_arn" {
+  description = "The ARN of the API Gateway 4xx alarm (null if disabled)"
+  value       = try(aws_cloudwatch_metric_alarm.apigw_4xx[0].arn, null)
+}
+
+output "apigw_latency_alarm_arn" {
+  description = "The ARN of the API Gateway latency alarm (null if disabled)"
+  value       = try(aws_cloudwatch_metric_alarm.apigw_latency[0].arn, null)
+}
+
+output "vpc_rejected_alarm_arn" {
+  description = "The ARN of the VPC rejected packets alarm (null if disabled)"
+  value       = try(aws_cloudwatch_metric_alarm.vpc_rejected_packets[0].arn, null)
+}

--- a/infra/modules/cloudwatch_alarms/variables.tf
+++ b/infra/modules/cloudwatch_alarms/variables.tf
@@ -1,0 +1,227 @@
+# -----------------------------------------------------------------------------
+# General Variables
+# -----------------------------------------------------------------------------
+
+variable "name" {
+  description = "Name prefix for alarm resources"
+  type        = string
+  default     = "infra"
+}
+
+variable "environment" {
+  description = "Environment name used for tagging and naming (e.g., dev, staging, prod)"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "Environment must be one of: dev, staging, prod."
+  }
+}
+
+variable "kms_key_arn" {
+  description = "ARN of a KMS key for SNS topic encryption. If null, SNS encryption is disabled."
+  type        = string
+  default     = null
+}
+
+variable "remediation_lambda_arn" {
+  description = "ARN of an optional Lambda function for auto-remediation actions"
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "Additional tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+# -----------------------------------------------------------------------------
+# ALB Variables
+# -----------------------------------------------------------------------------
+
+variable "alb_arn_suffix" {
+  description = "ARN suffix of the ALB (required when ALB alarms are enabled)"
+  type        = string
+  default     = ""
+}
+
+variable "alb_target_group_arn_suffix" {
+  description = "ARN suffix of the ALB target group (required when ALB unhealthy alarm is enabled)"
+  type        = string
+  default     = ""
+}
+
+# ALB 5xx Alarm
+
+variable "enable_alb_5xx_alarm" {
+  description = "Enable the ALB 5xx error rate alarm"
+  type        = bool
+  default     = false
+}
+
+variable "alb_5xx_threshold" {
+  description = "Number of ALB 5xx errors to trigger the alarm"
+  type        = number
+  default     = 50
+}
+
+variable "alb_5xx_period" {
+  description = "Period in seconds over which the ALB 5xx metric is evaluated"
+  type        = number
+  default     = 300
+}
+
+variable "alb_5xx_evaluation_periods" {
+  description = "Number of evaluation periods before the ALB 5xx alarm triggers"
+  type        = number
+  default     = 3
+}
+
+# ALB Unhealthy Targets Alarm
+
+variable "enable_alb_unhealthy_alarm" {
+  description = "Enable the ALB unhealthy targets alarm"
+  type        = bool
+  default     = false
+}
+
+variable "alb_unhealthy_threshold" {
+  description = "Number of unhealthy targets to trigger the alarm"
+  type        = number
+  default     = 0
+}
+
+variable "alb_unhealthy_period" {
+  description = "Period in seconds over which the ALB unhealthy targets metric is evaluated"
+  type        = number
+  default     = 300
+}
+
+variable "alb_unhealthy_evaluation_periods" {
+  description = "Number of evaluation periods before the ALB unhealthy targets alarm triggers"
+  type        = number
+  default     = 3
+}
+
+# -----------------------------------------------------------------------------
+# API Gateway Variables
+# -----------------------------------------------------------------------------
+
+variable "apigw_api_id" {
+  description = "API Gateway API ID (required when API Gateway alarms are enabled)"
+  type        = string
+  default     = ""
+}
+
+# API Gateway 5xx Alarm
+
+variable "enable_apigw_5xx_alarm" {
+  description = "Enable the API Gateway 5xx error rate alarm"
+  type        = bool
+  default     = false
+}
+
+variable "apigw_5xx_threshold" {
+  description = "Number of API Gateway 5xx errors to trigger the alarm"
+  type        = number
+  default     = 50
+}
+
+variable "apigw_5xx_period" {
+  description = "Period in seconds over which the API Gateway 5xx metric is evaluated"
+  type        = number
+  default     = 300
+}
+
+variable "apigw_5xx_evaluation_periods" {
+  description = "Number of evaluation periods before the API Gateway 5xx alarm triggers"
+  type        = number
+  default     = 3
+}
+
+# API Gateway 4xx Alarm
+
+variable "enable_apigw_4xx_alarm" {
+  description = "Enable the API Gateway 4xx error rate alarm"
+  type        = bool
+  default     = false
+}
+
+variable "apigw_4xx_threshold" {
+  description = "Number of API Gateway 4xx errors to trigger the alarm"
+  type        = number
+  default     = 200
+}
+
+variable "apigw_4xx_period" {
+  description = "Period in seconds over which the API Gateway 4xx metric is evaluated"
+  type        = number
+  default     = 300
+}
+
+variable "apigw_4xx_evaluation_periods" {
+  description = "Number of evaluation periods before the API Gateway 4xx alarm triggers"
+  type        = number
+  default     = 3
+}
+
+# API Gateway Latency Alarm
+
+variable "enable_apigw_latency_alarm" {
+  description = "Enable the API Gateway latency alarm"
+  type        = bool
+  default     = false
+}
+
+variable "apigw_latency_threshold" {
+  description = "API Gateway p99 latency threshold in milliseconds"
+  type        = number
+  default     = 5000
+}
+
+variable "apigw_latency_period" {
+  description = "Period in seconds over which the API Gateway latency metric is evaluated"
+  type        = number
+  default     = 300
+}
+
+variable "apigw_latency_evaluation_periods" {
+  description = "Number of evaluation periods before the API Gateway latency alarm triggers"
+  type        = number
+  default     = 3
+}
+
+# -----------------------------------------------------------------------------
+# VPC Flow Logs Variables
+# -----------------------------------------------------------------------------
+
+variable "vpc_flow_log_group_name" {
+  description = "CloudWatch Log Group name for VPC Flow Logs (required when VPC alarm is enabled)"
+  type        = string
+  default     = ""
+}
+
+variable "enable_vpc_rejected_alarm" {
+  description = "Enable the VPC Flow Logs rejected packets alarm"
+  type        = bool
+  default     = false
+}
+
+variable "vpc_rejected_threshold" {
+  description = "Number of rejected packets to trigger the alarm"
+  type        = number
+  default     = 1000
+}
+
+variable "vpc_rejected_period" {
+  description = "Period in seconds over which the VPC rejected packets metric is evaluated"
+  type        = number
+  default     = 300
+}
+
+variable "vpc_rejected_evaluation_periods" {
+  description = "Number of evaluation periods before the VPC rejected packets alarm triggers"
+  type        = number
+  default     = 3
+}


### PR DESCRIPTION
## Summary
- New `cloudwatch_alarms` module with SNS topic (KMS-encrypted) and 6 configurable alarms
- Monitors ALB 5xx errors, unhealthy targets, API Gateway 5xx/4xx/latency, VPC rejected packets
- Optional Lambda remediation ARN for automated incident response
- Full README with usage examples, inputs/outputs tables

Closes #31

## FedRAMP Controls
SI-4 (System Monitoring), SI-5 (Security Alerts), IR-4 (Incident Handling), AU-6 (Audit Review)

## Test Plan
- [ ] `tofu validate` passes on module
- [ ] All alarms conditionally created via `enable_*` variables
- [ ] SNS topic encrypted with provided KMS key

🤖 Generated with [Claude Code](https://claude.com/claude-code)