### PR TITLE
Remove REST API v1 resources from API Gateway module

### DIFF
--- a/infra/modules/api_gateway/README.md
+++ b/infra/modules/api_gateway/README.md
@@ -77,10 +77,10 @@ module "api_gateway" {
 | ------------------------------- | -------------- | ---------------------------------------------------- | -------- | ---------------------------------------------- |
 | `name`                          | `string`       | `api`                                                | no       | API name (prefixed with environment)           |
 | `description`                   | `string`       | `""`                                                 | no       | API description                                |
-| `environment`                   | `string`       | —                                                    | yes      | Environment name (dev, staging, prod)          |
+| `environment`                   | `string`       | ---                                                    | yes      | Environment name (dev, staging, prod)          |
 | `enable_auto_deploy`            | `bool`         | `true`                                               | no       | Auto-deploy changes to default stage           |
-| `throttling_rate_limit`         | `number`       | `1000`                                               | no       | Requests/second rate limit (1–10000)           |
-| `throttling_burst_limit`        | `number`       | `500`                                                | no       | Burst capacity (1–5000)                        |
+| `throttling_rate_limit`         | `number`       | `1000`                                               | no       | Requests/second rate limit (1--10000)           |
+| `throttling_burst_limit`        | `number`       | `500`                                                | no       | Burst capacity (1--5000)                        |
 | `enable_access_logging`         | `bool`         | `true`                                               | no       | Enable CloudWatch access logging               |
 | `log_retention_days`            | `number`       | `90`                                                 | no       | Log retention in days                          |
 | `kms_key_arn`                   | `string`       | `null`                                               | no       | KMS key for log encryption (null = AWS default)|
@@ -108,14 +108,13 @@ module "api_gateway" {
 | `cloudwatch_log_group_name`| Log group name (null if logging disabled)           |
 | `cloudwatch_log_group_arn` | Log group ARN (null if logging disabled)            |
 | `vpc_link_id`              | VPC Link ID (null if no VPC Link)                   |
-| `execution_role_arn`       | IAM role ARN for logging (null if logging disabled) |
 
 ## Security Features
 
 - **Access logging**: CloudWatch Logs enabled by default with 90-day retention
 - **Log encryption**: Optional customer-managed KMS key (FedRAMP AU-9, SC-28)
 - **Throttling**: Configurable rate and burst limits to prevent abuse (SEC-06)
-- **Least-privilege IAM**: Logging role scoped to specific log group ARN (AC-6)
+- **Least-privilege logging**: CloudWatch access logging scoped to specific log group
 - **WAF integration**: Optional WAFv2 association for OWASP Top 10 protection (SC-7)
 - **VPC Link**: Optional private backend connectivity (SC-7)
 - **CORS**: Restrictive by default, configurable origins and methods
@@ -125,7 +124,6 @@ module "api_gateway" {
 
 | Control | Requirement                          | Implementation                              |
 | ------- | ------------------------------------ | ------------------------------------------- |
-| AC-6    | Least privilege                      | IAM role scoped to log group ARN            |
 | AU-2    | Audit events                         | CloudWatch access logs enabled by default   |
 | AU-3    | Content of audit records             | Request/response metadata in access logs    |
 | AU-9    | Protection of audit information      | KMS encryption on log group                 |

--- a/infra/modules/api_gateway/outputs.tf
+++ b/infra/modules/api_gateway/outputs.tf
@@ -37,8 +37,3 @@ output "vpc_link_id" {
   description = "The ID of the VPC Link (null if no VPC Link created)"
   value       = try(aws_apigatewayv2_vpc_link.this[0].id, null)
 }
-
-output "execution_role_arn" {
-  description = "The ARN of the IAM role used for CloudWatch logging (null if logging disabled)"
-  value       = try(aws_iam_role.api_logging[0].arn, null)
-}

--- a/infra/modules/api_gateway/variables.tf
+++ b/infra/modules/api_gateway/variables.tf
@@ -144,6 +144,11 @@ variable "vpc_link_security_group_ids" {
   description = "List of security group IDs for the VPC Link"
   type        = list(string)
   default     = []
+
+  validation {
+    condition     = length(var.vpc_link_subnet_ids) == 0 || length(var.vpc_link_security_group_ids) > 0
+    error_message = "vpc_link_security_group_ids must be non-empty when vpc_link_subnet_ids is provided."
+  }
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Remove `aws_api_gateway_account`, `aws_iam_role.api_logging`, and `aws_iam_role_policy.api_logging` — REST API v1 resources unnecessary for HTTP API v2
- HTTP API v2 access logging works natively via `access_log_settings.destination_arn` on stage
- Remove `execution_role_arn` output
- Add validation: `vpc_link_security_group_ids` must be non-empty when `vpc_link_subnet_ids` is provided

Closes #37

## Test Plan
- [ ] `tofu validate` passes
- [ ] Access logging still works via stage `access_log_settings`
- [ ] VPC Link validation prevents misconfiguration

🤖 Generated with [Claude Code](https://claude.com/claude-code)