### PR TITLE
Add CallerAccount condition to KMS S3 policy

### DIFF
--- a/infra/modules/kms/main.tf
+++ b/infra/modules/kms/main.tf
@@ -150,6 +150,12 @@ data "aws_iam_policy_document" "key_policy" {
         "kms:ReEncrypt*"
       ]
       resources = ["*"]
+
+      condition {
+        test     = "StringEquals"
+        variable = "kms:CallerAccount"
+        values   = [data.aws_caller_identity.current.account_id]
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add `kms:CallerAccount` condition to S3 service policy statement
- Prevents cross-account S3 services from using the key
- Restricts key usage to S3 within the owning AWS account only

Closes #38

## Test Plan
- [ ] `tofu validate` passes
- [ ] S3 policy statement includes `StringEquals` condition on `kms:CallerAccount`

🤖 Generated with [Claude Code](https://claude.com/claude-code)