### PR TITLE
Add optional restricted egress to security groups

### DIFF
--- a/infra/modules/security_groups/variables.tf
+++ b/infra/modules/security_groups/variables.tf
@@ -70,6 +70,23 @@ variable "bastion_allowed_cidrs" {
   }
 }
 
+variable "restrict_egress" {
+  description = "Whether to restrict egress to minimum required ports instead of allowing all outbound"
+  type        = bool
+  default     = false
+}
+
+variable "vpc_cidr_block" {
+  description = "CIDR block of the VPC (used for bastion SSH egress when restrict_egress is true)"
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.vpc_cidr_block == "" || can(cidrhost(var.vpc_cidr_block, 0))
+    error_message = "Must be a valid IPv4 CIDR block or empty string."
+  }
+}
+
 variable "tags" {
   description = "Additional tags to apply to all resources"
   type        = map(string)


### PR DESCRIPTION
## Summary
- Add `restrict_egress` variable (default `false` for backwards compatibility)
- When enabled, replaces unrestricted egress with per-tier allowlists:
  - **Web**: HTTPS (443), DNS (53), NTP (123)
  - **App**: DB port to DB SG, HTTPS, DNS, NTP
  - **DB**: DNS, NTP only
  - **Bastion**: SSH (22) to VPC CIDR, DNS, NTP
- Add `vpc_cidr_block` variable for bastion SSH egress scoping
- Updated README with restricted egress example and port tables

Closes #27

## Test Plan
- [ ] `tofu validate` passes with both `restrict_egress = true` and `false`
- [ ] Default behavior unchanged (unrestricted egress)
- [ ] Restricted mode creates correct per-tier rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)