### PR TITLE
Replace ASCII art with teal SVG banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,6 @@
 <p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/%E2%96%B2-CLOUD_VOYAGER_INFRA-00FFFF?style=for-the-badge&labelColor=0a0a0a">
-    <img alt="Cloud Voyager Infra" src="https://img.shields.io/badge/%E2%96%B2-CLOUD_VOYAGER_INFRA-00FFFF?style=for-the-badge&labelColor=0a0a0a">
-  </picture>
+  <img src="docs/banner.svg" alt="Cloud Voyager Infra" width="820">
 </p>
-
-```
- ╔══════════════════════════════════════════════════════════════════════════╗
- ║                                                                        ║
- ║    ██████╗██╗      ██████╗ ██╗   ██╗██████╗                            ║
- ║   ██╔════╝██║     ██╔═══██╗██║   ██║██╔══██╗                           ║
- ║   ██║     ██║     ██║   ██║██║   ██║██║  ██║                           ║
- ║   ██║     ██║     ██║   ██║██║   ██║██║  ██║                           ║
- ║   ╚██████╗███████╗╚██████╔╝╚██████╔╝██████╔╝                          ║
- ║    ╚═════╝╚══════╝ ╚═════╝  ╚═════╝ ╚═════╝                           ║
- ║   ██╗   ██╗ ██████╗ ██╗   ██╗ █████╗  ██████╗ ███████╗██████╗         ║
- ║   ██║   ██║██╔═══██╗╚██╗ ██╔╝██╔══██╗██╔════╝ ██╔════╝██╔══██╗       ║
- ║   ██║   ██║██║   ██║ ╚████╔╝ ███████║██║  ███╗█████╗  ██████╔╝       ║
- ║   ╚██╗ ██╔╝██║   ██║  ╚██╔╝  ██╔══██║██║   ██║██╔══╝  ██╔══██╗      ║
- ║    ╚████╔╝ ╚██████╔╝   ██║   ██║  ██║╚██████╔╝███████╗██║  ██║       ║
- ║     ╚═══╝   ╚═════╝    ╚═╝   ╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚═╝  ╚═╝      ║
- ║                                                                        ║
- ║              I N F R A S T R U C T U R E   A S   C O D E              ║
- ║                                                                        ║
- ╚══════════════════════════════════════════════════════════════════════════╝
-```
 
 <p align="center">
   <img src="https://img.shields.io/badge/OpenTofu-%3E%3D1.11.0-00FFFF?style=flat-square&logo=opentofu&logoColor=00FFFF&labelColor=0d1117" alt="OpenTofu">

--- a/docs/banner.svg
+++ b/docs/banner.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="440" viewBox="0 0 820 440">
+  <defs>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="2" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <linearGradient id="teal-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#00e5ff;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#00bcd4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="border-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#005f6b;stop-opacity:1" />
+      <stop offset="30%" style="stop-color:#00e5ff;stop-opacity:1" />
+      <stop offset="70%" style="stop-color:#00e5ff;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#005f6b;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="820" height="440" rx="8" fill="#0d1117"/>
+
+  <!-- Grid lines (subtle) -->
+  <g stroke="#0a3d42" stroke-width="0.5" opacity="0.3">
+    <line x1="0" y1="80" x2="820" y2="80"/>
+    <line x1="0" y1="160" x2="820" y2="160"/>
+    <line x1="0" y1="240" x2="820" y2="240"/>
+    <line x1="0" y1="320" x2="820" y2="320"/>
+    <line x1="160" y1="0" x2="160" y2="440"/>
+    <line x1="320" y1="0" x2="320" y2="440"/>
+    <line x1="480" y1="0" x2="480" y2="440"/>
+    <line x1="640" y1="0" x2="640" y2="440"/>
+  </g>
+
+  <!-- Border -->
+  <rect x="20" y="20" width="780" height="400" rx="4" fill="none" stroke="url(#border-gradient)" stroke-width="2"/>
+
+  <!-- Inner glow border -->
+  <rect x="24" y="24" width="772" height="392" rx="2" fill="none" stroke="#00e5ff" stroke-width="0.5" opacity="0.3"/>
+
+  <!-- CLOUD - block letters -->
+  <g filter="url(#glow)" fill="url(#teal-gradient)" font-family="'Courier New', monospace" font-size="14" font-weight="bold">
+    <text x="410" y="70" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
+      ██████╗██╗      ██████╗ ██╗   ██╗██████╗
+    </text>
+    <text x="410" y="88" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
+     ██╔════╝██║     ██╔═══██╗██║   ██║██╔══██╗
+    </text>
+    <text x="410" y="106" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
+     ██║     ██║     ██║   ██║██║   ██║██║  ██║
+    </text>
+    <text x="410" y="124" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
+     ██║     ██║     ██║   ██║██║   ██║██║  ██║
+    </text>
+    <text x="410" y="142" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
+     ╚██████╗███████╗╚██████╔╝╚██████╔╝██████╔╝
+    </text>
+    <text x="410" y="160" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
+      ╚═════╝╚══════╝ ╚═════╝  ╚═════╝ ╚═════╝
+    </text>
+
+    <!-- VOYAGER - block letters -->
+    <text x="410" y="195" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
+     ██╗   ██╗ ██████╗ ██╗   ██╗ █████╗  ██████╗ ███████╗██████╗
+    </text>
+    <text x="410" y="213" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
+     ██║   ██║██╔═══██╗╚██╗ ██╔╝██╔══██╗██╔════╝ ██╔════╝██╔══██╗
+    </text>
+    <text x="410" y="231" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
+     ██║   ██║██║   ██║ ╚████╔╝ ███████║██║  ███╗█████╗  ██████╔╝
+    </text>
+    <text x="410" y="249" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
+     ╚██╗ ██╔╝██║   ██║  ╚██╔╝  ██╔══██║██║   ██║██╔══╝  ██╔══██╗
+    </text>
+    <text x="410" y="267" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
+      ╚████╔╝ ╚██████╔╝   ██║   ██║  ██║╚██████╔╝███████╗██║  ██║
+    </text>
+    <text x="410" y="285" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
+       ╚═══╝   ╚═════╝    ╚═╝   ╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚═╝  ╚═╝
+    </text>
+  </g>
+
+  <!-- Subtitle -->
+  <text x="410" y="340" text-anchor="middle" style="font-family:monospace;font-size:16px;letter-spacing:8px;fill:#00bcd4" filter="url(#glow)">
+    INFRASTRUCTURE AS CODE
+  </text>
+
+  <!-- Horizontal accent lines -->
+  <line x1="140" y1="365" x2="680" y2="365" stroke="url(#border-gradient)" stroke-width="1" opacity="0.6"/>
+
+  <!-- Tagline -->
+  <text x="410" y="393" text-anchor="middle" style="font-family:monospace;font-size:11px;fill:#4db6ac;opacity:0.8">
+    "The Grid. A digital frontier."
+  </text>
+</svg>


### PR DESCRIPTION
## Summary
- Add `docs/banner.svg` with TRON-style teal (#00e5ff) block letters on dark background
- SVG includes grid lines, glow filter, gradient borders, and tagline
- Replace plain code block in README with the SVG image

## Test Plan
- [ ] SVG renders correctly on GitHub README
- [ ] Dark and light mode both display properly