### PR TITLE
Fix banner: replace block chars with legible text

### DIFF
--- a/docs/banner.svg
+++ b/docs/banner.svg
@@ -1,97 +1,87 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="440" viewBox="0 0 820 440">
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="340" viewBox="0 0 820 340">
   <defs>
     <filter id="glow">
-      <feGaussianBlur stdDeviation="2" result="blur"/>
+      <feGaussianBlur stdDeviation="3" result="blur"/>
       <feMerge>
         <feMergeNode in="blur"/>
         <feMergeNode in="SourceGraphic"/>
       </feMerge>
     </filter>
-    <linearGradient id="teal-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#00e5ff;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#00bcd4;stop-opacity:1" />
+    <filter id="glow-strong">
+      <feGaussianBlur stdDeviation="6" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <linearGradient id="border-grad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#003844;stop-opacity:1"/>
+      <stop offset="20%" style="stop-color:#00e5ff;stop-opacity:1"/>
+      <stop offset="80%" style="stop-color:#00e5ff;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#003844;stop-opacity:1"/>
     </linearGradient>
-    <linearGradient id="border-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#005f6b;stop-opacity:1" />
-      <stop offset="30%" style="stop-color:#00e5ff;stop-opacity:1" />
-      <stop offset="70%" style="stop-color:#00e5ff;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#005f6b;stop-opacity:1" />
+    <linearGradient id="text-grad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#00ffff;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#00b8d4;stop-opacity:1"/>
+    </linearGradient>
+    <linearGradient id="sub-grad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#004d5a;stop-opacity:1"/>
+      <stop offset="50%" style="stop-color:#00e5ff;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#004d5a;stop-opacity:1"/>
     </linearGradient>
   </defs>
 
   <!-- Background -->
-  <rect width="820" height="440" rx="8" fill="#0d1117"/>
+  <rect width="820" height="340" rx="8" fill="#0a0e14"/>
 
-  <!-- Grid lines (subtle) -->
-  <g stroke="#0a3d42" stroke-width="0.5" opacity="0.3">
-    <line x1="0" y1="80" x2="820" y2="80"/>
-    <line x1="0" y1="160" x2="820" y2="160"/>
-    <line x1="0" y1="240" x2="820" y2="240"/>
-    <line x1="0" y1="320" x2="820" y2="320"/>
-    <line x1="160" y1="0" x2="160" y2="440"/>
-    <line x1="320" y1="0" x2="320" y2="440"/>
-    <line x1="480" y1="0" x2="480" y2="440"/>
-    <line x1="640" y1="0" x2="640" y2="440"/>
+  <!-- Grid lines -->
+  <g stroke="#00e5ff" stroke-width="0.3" opacity="0.07">
+    <line x1="0" y1="68" x2="820" y2="68"/>
+    <line x1="0" y1="136" x2="820" y2="136"/>
+    <line x1="0" y1="204" x2="820" y2="204"/>
+    <line x1="0" y1="272" x2="820" y2="272"/>
+    <line x1="164" y1="0" x2="164" y2="340"/>
+    <line x1="328" y1="0" x2="328" y2="340"/>
+    <line x1="492" y1="0" x2="492" y2="340"/>
+    <line x1="656" y1="0" x2="656" y2="340"/>
   </g>
 
-  <!-- Border -->
-  <rect x="20" y="20" width="780" height="400" rx="4" fill="none" stroke="url(#border-gradient)" stroke-width="2"/>
+  <!-- Outer border -->
+  <rect x="16" y="16" width="788" height="308" rx="4" fill="none" stroke="url(#border-grad)" stroke-width="1.5"/>
 
   <!-- Inner glow border -->
-  <rect x="24" y="24" width="772" height="392" rx="2" fill="none" stroke="#00e5ff" stroke-width="0.5" opacity="0.3"/>
+  <rect x="20" y="20" width="780" height="300" rx="3" fill="none" stroke="#00e5ff" stroke-width="0.4" opacity="0.2"/>
 
-  <!-- CLOUD - block letters -->
-  <g filter="url(#glow)" fill="url(#teal-gradient)" font-family="'Courier New', monospace" font-size="14" font-weight="bold">
-    <text x="410" y="70" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
-      ██████╗██╗      ██████╗ ██╗   ██╗██████╗
-    </text>
-    <text x="410" y="88" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
-     ██╔════╝██║     ██╔═══██╗██║   ██║██╔══██╗
-    </text>
-    <text x="410" y="106" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
-     ██║     ██║     ██║   ██║██║   ██║██║  ██║
-    </text>
-    <text x="410" y="124" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
-     ██║     ██║     ██║   ██║██║   ██║██║  ██║
-    </text>
-    <text x="410" y="142" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
-     ╚██████╗███████╗╚██████╔╝╚██████╔╝██████╔╝
-    </text>
-    <text x="410" y="160" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
-      ╚═════╝╚══════╝ ╚═════╝  ╚═════╝ ╚═════╝
-    </text>
+  <!-- Decorative top line -->
+  <line x1="160" y1="60" x2="660" y2="60" stroke="url(#sub-grad)" stroke-width="0.8" opacity="0.5"/>
 
-    <!-- VOYAGER - block letters -->
-    <text x="410" y="195" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
-     ██╗   ██╗ ██████╗ ██╗   ██╗ █████╗  ██████╗ ███████╗██████╗
-    </text>
-    <text x="410" y="213" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
-     ██║   ██║██╔═══██╗╚██╗ ██╔╝██╔══██╗██╔════╝ ██╔════╝██╔══██╗
-    </text>
-    <text x="410" y="231" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
-     ██║   ██║██║   ██║ ╚████╔╝ ███████║██║  ███╗█████╗  ██████╔╝
-    </text>
-    <text x="410" y="249" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
-     ╚██╗ ██╔╝██║   ██║  ╚██╔╝  ██╔══██║██║   ██║██╔══╝  ██╔══██╗
-    </text>
-    <text x="410" y="267" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
-      ╚████╔╝ ╚██████╔╝   ██║   ██║  ██║╚██████╔╝███████╗██║  ██║
-    </text>
-    <text x="410" y="285" text-anchor="middle" style="font-family:monospace;font-size:14px;fill:#00e5ff">
-       ╚═══╝   ╚═════╝    ╚═╝   ╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚═╝  ╚═╝
-    </text>
-  </g>
+  <!-- CLOUD -->
+  <text x="410" y="125" text-anchor="middle" filter="url(#glow-strong)"
+        style="font-family:'Segoe UI','Helvetica Neue',Arial,sans-serif;font-size:72px;font-weight:800;letter-spacing:18px;fill:url(#text-grad)">
+    CLOUD
+  </text>
+
+  <!-- VOYAGER -->
+  <text x="410" y="195" text-anchor="middle" filter="url(#glow-strong)"
+        style="font-family:'Segoe UI','Helvetica Neue',Arial,sans-serif;font-size:72px;font-weight:800;letter-spacing:18px;fill:url(#text-grad)">
+    VOYAGER
+  </text>
+
+  <!-- Decorative middle line -->
+  <line x1="200" y1="220" x2="620" y2="220" stroke="url(#sub-grad)" stroke-width="0.8" opacity="0.5"/>
 
   <!-- Subtitle -->
-  <text x="410" y="340" text-anchor="middle" style="font-family:monospace;font-size:16px;letter-spacing:8px;fill:#00bcd4" filter="url(#glow)">
+  <text x="410" y="258" text-anchor="middle" filter="url(#glow)"
+        style="font-family:'Courier New',monospace;font-size:14px;letter-spacing:10px;fill:#00bcd4">
     INFRASTRUCTURE AS CODE
   </text>
 
-  <!-- Horizontal accent lines -->
-  <line x1="140" y1="365" x2="680" y2="365" stroke="url(#border-gradient)" stroke-width="1" opacity="0.6"/>
+  <!-- Decorative bottom line -->
+  <line x1="160" y1="280" x2="660" y2="280" stroke="url(#sub-grad)" stroke-width="0.8" opacity="0.5"/>
 
   <!-- Tagline -->
-  <text x="410" y="393" text-anchor="middle" style="font-family:monospace;font-size:11px;fill:#4db6ac;opacity:0.8">
+  <text x="410" y="305" text-anchor="middle"
+        style="font-family:'Courier New',monospace;font-size:11px;fill:#4db6ac;opacity:0.7">
     "The Grid. A digital frontier."
   </text>
 </svg>


### PR DESCRIPTION
## Summary
- Replace Unicode block characters with clean sans-serif text (72px bold)
- GitHub SVG renderer doesn't support block drawing characters
- Teal gradient fill, glow filters, grid lines, and border styling preserved
- Compact height (340px vs 440px)