### PR TITLE
Add VPC Endpoints module for S3 and DynamoDB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,8 @@ cloud-voyager-infra/
         ├── api_gateway/             # API Gateway v2 (HTTP API)
         ├── kms/                     # Customer-managed encryption keys
         ├── remote_state/            # S3 + DynamoDB state backend
-        └── cloudwatch_alarms/       # SNS + alarms for observability
+        ├── cloudwatch_alarms/       # SNS + alarms for observability
+        └── vpc_endpoints/           # S3 + DynamoDB Gateway endpoints
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ cloud-voyager-infra/
 │   │   ├── api-gateway.md
 │   │   ├── kms.md
 │   │   ├── remote-state.md
-│   │   └── cloudwatch-alarms.md
+│   │   ├── cloudwatch-alarms.md
+│   │   └── vpc-endpoints.md
 │   └── infracost-setup.md           // CI cost estimation setup guide
 ├── infra/
 │   ├── modules/
@@ -46,7 +47,8 @@ cloud-voyager-infra/
 │   │   ├── api_gateway/             // API Gateway v2 (HTTP API)
 │   │   ├── kms/                     // Customer-managed encryption keys
 │   │   ├── remote_state/            // S3 + DynamoDB state backend
-│   │   └── cloudwatch_alarms/       // SNS + alarms for observability
+│   │   ├── cloudwatch_alarms/       // SNS + alarms for observability
+│   │   └── vpc_endpoints/           // S3 + DynamoDB Gateway endpoints
 │   ├── main.tf                      // Root config — wires modules
 │   ├── variables.tf                 // Root-level variables
 │   ├── outputs.tf                   // Root-level outputs
@@ -181,6 +183,20 @@ SNS topic with KMS encryption and configurable alarms for ALB errors, API Gatewa
 </td>
 <td width="50%" valign="top">
 
+### `[VPC ENDPOINTS]`
+**Private Network Paths**
+
+Gateway VPC Endpoints for S3 and DynamoDB. Routes traffic over the AWS backbone, eliminating NAT costs and public internet exposure.
+
+`FedRAMP: SC-7 · AC-4 · SC-8`
+
+[`> ACCESS DISC`](infra/modules/vpc_endpoints/README.md)
+
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+
 ### `[CI/CD PIPELINE]`
 **Automated Sentinel**
 
@@ -189,6 +205,11 @@ GitHub Actions workflow: `tofu plan` + `tofu validate` + `tofu fmt` on every PR.
 `FedRAMP: SA-11 · CM-3 · SC-8`
 
 [`> ACCESS DISC`](.github/workflows/tofu-plan.yml)
+
+</td>
+<td width="50%" valign="top">
+
+&nbsp;
 
 </td>
 </tr>

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -11,3 +11,4 @@ Per-module Mermaid diagrams for the cloud-voyager-infra modules.
 | KMS | [kms.md](kms.md) |
 | Remote State | [remote-state.md](remote-state.md) |
 | CloudWatch Alarms | [cloudwatch-alarms.md](cloudwatch-alarms.md) |
+| VPC Endpoints | [vpc-endpoints.md](vpc-endpoints.md) |

--- a/docs/architecture/vpc-endpoints.md
+++ b/docs/architecture/vpc-endpoints.md
@@ -1,0 +1,57 @@
+# VPC Endpoints Architecture
+
+## Overview
+
+Gateway VPC Endpoints route traffic to S3 and DynamoDB over the AWS private backbone, eliminating the need for NAT Gateways, internet gateways, or public IP addresses for these services.
+
+## Architecture Diagram
+
+```mermaid
+graph LR
+    subgraph VPC
+        subgraph Private Subnets
+            EC2[EC2 / ECS Tasks]
+        end
+
+        subgraph Route Tables
+            PubRT[Public RT]
+            PrivRT[Private RT]
+        end
+
+        S3EP[S3 Gateway<br>Endpoint]
+        DDBEP[DynamoDB Gateway<br>Endpoint]
+    end
+
+    S3[(Amazon S3)]
+    DDB[(Amazon DynamoDB)]
+
+    EC2 -->|Route via RT| PrivRT
+    PrivRT -->|Prefix list route| S3EP
+    PrivRT -->|Prefix list route| DDBEP
+    PubRT -->|Prefix list route| S3EP
+    PubRT -->|Prefix list route| DDBEP
+    S3EP -->|AWS backbone| S3
+    DDBEP -->|AWS backbone| DDB
+```
+
+## How It Works
+
+1. When a Gateway endpoint is created, AWS adds a route to each associated route table
+2. The route uses a **prefix list** (managed by AWS) containing the IP ranges for the service
+3. Traffic matching these prefixes is routed to the endpoint instead of the internet
+4. The endpoint policy (optional) controls which S3 buckets or DynamoDB tables are accessible
+
+## Design Decisions
+
+| Decision | Rationale |
+| --- | --- |
+| Gateway (not Interface) for S3/DynamoDB | Gateway endpoints are free; Interface endpoints incur hourly + data charges |
+| Endpoint policy defaults to full access | Restrictive policies should be set per-environment via the `s3_endpoint_policy` variable |
+| Both public and private route tables | Ensures all subnets route S3/DynamoDB traffic over the private network |
+| DynamoDB disabled by default | Not all workloads use DynamoDB; opt-in reduces unnecessary resources |
+
+## Security Considerations
+
+- **Endpoint policies**: Use `s3_endpoint_policy` to restrict which buckets are accessible from the VPC
+- **Bucket policies**: Combine with S3 bucket policies using `aws:sourceVpce` condition to enforce VPC-only access
+- **No public internet**: Traffic stays within AWS infrastructure, satisfying FedRAMP SC-7 boundary protection

--- a/infra/modules/vpc_endpoints/README.md
+++ b/infra/modules/vpc_endpoints/README.md
@@ -1,0 +1,118 @@
+# VPC Endpoints Module
+
+Creates Gateway VPC Endpoints for S3 and DynamoDB. Gateway endpoints route traffic to AWS services over the AWS private network instead of the public internet, reducing data transfer costs and improving security posture.
+
+## Usage
+
+### S3 Endpoint Only
+
+```hcl
+module "vpc_endpoints" {
+  source = "git::https://github.com/jsandov/cloud-voyager-infra.git//infra/modules/vpc_endpoints?ref=v1.0.0"
+
+  vpc_id      = module.vpc.vpc_id
+  environment = "prod"
+
+  route_table_ids = [
+    module.vpc.public_route_table_id,
+    module.vpc.private_route_table_id,
+  ]
+
+  tags = {
+    Project = "my-project"
+  }
+}
+```
+
+### S3 + DynamoDB Endpoints
+
+```hcl
+module "vpc_endpoints" {
+  source = "git::https://github.com/jsandov/cloud-voyager-infra.git//infra/modules/vpc_endpoints?ref=v1.0.0"
+
+  vpc_id      = module.vpc.vpc_id
+  environment = "prod"
+
+  route_table_ids = [
+    module.vpc.public_route_table_id,
+    module.vpc.private_route_table_id,
+  ]
+
+  enable_s3_endpoint       = true
+  enable_dynamodb_endpoint = true
+
+  tags = {
+    Project = "my-project"
+  }
+}
+```
+
+### With Restricted S3 Endpoint Policy
+
+```hcl
+module "vpc_endpoints" {
+  source = "git::https://github.com/jsandov/cloud-voyager-infra.git//infra/modules/vpc_endpoints?ref=v1.0.0"
+
+  vpc_id      = module.vpc.vpc_id
+  environment = "prod"
+
+  route_table_ids = [
+    module.vpc.private_route_table_id,
+  ]
+
+  s3_endpoint_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid       = "AllowSpecificBucket"
+      Effect    = "Allow"
+      Principal = "*"
+      Action    = ["s3:GetObject", "s3:PutObject", "s3:ListBucket"]
+      Resource  = [
+        "arn:aws:s3:::my-app-bucket",
+        "arn:aws:s3:::my-app-bucket/*"
+      ]
+    }]
+  })
+
+  tags = {
+    Project = "my-project"
+  }
+}
+```
+
+## Inputs
+
+| Name                       | Type           | Default | Required | Description                                              |
+| -------------------------- | -------------- | ------- | -------- | -------------------------------------------------------- |
+| `vpc_id`                   | `string`       | --      | yes      | VPC ID to create endpoints in                            |
+| `environment`              | `string`       | --      | yes      | Environment name for tagging (dev, staging, prod)        |
+| `route_table_ids`          | `list(string)` | --      | yes      | Route table IDs to associate with Gateway endpoints      |
+| `enable_s3_endpoint`       | `bool`         | `true`  | no       | Create an S3 Gateway VPC Endpoint                        |
+| `enable_dynamodb_endpoint` | `bool`         | `false` | no       | Create a DynamoDB Gateway VPC Endpoint                   |
+| `s3_endpoint_policy`       | `string`       | `null`  | no       | Custom IAM policy for S3 endpoint (null = full access)   |
+| `dynamodb_endpoint_policy` | `string`       | `null`  | no       | Custom IAM policy for DynamoDB endpoint (null = full access) |
+| `tags`                     | `map(string)`  | `{}`    | no       | Additional tags for all resources                        |
+
+## Outputs
+
+| Name                              | Description                                              |
+| --------------------------------- | -------------------------------------------------------- |
+| `s3_endpoint_id`                  | ID of the S3 Gateway endpoint (null if disabled)         |
+| `s3_endpoint_prefix_list_id`      | Prefix list ID for S3 (use in security group rules)      |
+| `dynamodb_endpoint_id`            | ID of the DynamoDB Gateway endpoint (null if disabled)   |
+| `dynamodb_endpoint_prefix_list_id`| Prefix list ID for DynamoDB (use in security group rules)|
+
+## Why Gateway Endpoints?
+
+- **No cost**: Gateway endpoints for S3 and DynamoDB are free
+- **No NAT required**: Private subnets can access S3/DynamoDB without a NAT Gateway
+- **Better performance**: Traffic stays on the AWS backbone network
+- **Security**: Traffic never traverses the public internet
+
+## FedRAMP Controls
+
+| Control | Requirement                   | Implementation                                        |
+| ------- | ----------------------------- | ----------------------------------------------------- |
+| SC-7    | Boundary protection           | Traffic routed over AWS private network, not internet  |
+| AC-4    | Information flow enforcement  | Optional endpoint policies restrict access to specific buckets/tables |
+| SC-8    | Transmission confidentiality  | All traffic stays within AWS infrastructure            |

--- a/infra/modules/vpc_endpoints/main.tf
+++ b/infra/modules/vpc_endpoints/main.tf
@@ -1,0 +1,43 @@
+# -----------------------------------------------------------------------------
+# S3 Gateway VPC Endpoint
+# -----------------------------------------------------------------------------
+
+data "aws_region" "current" {}
+
+resource "aws_vpc_endpoint" "s3" {
+  count = var.enable_s3_endpoint ? 1 : 0
+
+  vpc_id            = var.vpc_id
+  service_name      = "com.amazonaws.${data.aws_region.current.name}.s3"
+  vpc_endpoint_type = "Gateway"
+  policy            = var.s3_endpoint_policy
+
+  route_table_ids = var.route_table_ids
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-s3-endpoint"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# DynamoDB Gateway VPC Endpoint
+# -----------------------------------------------------------------------------
+
+resource "aws_vpc_endpoint" "dynamodb" {
+  count = var.enable_dynamodb_endpoint ? 1 : 0
+
+  vpc_id            = var.vpc_id
+  service_name      = "com.amazonaws.${data.aws_region.current.name}.dynamodb"
+  vpc_endpoint_type = "Gateway"
+  policy            = var.dynamodb_endpoint_policy
+
+  route_table_ids = var.route_table_ids
+
+  tags = merge(var.tags, {
+    Name        = "${var.environment}-dynamodb-endpoint"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+  })
+}

--- a/infra/modules/vpc_endpoints/outputs.tf
+++ b/infra/modules/vpc_endpoints/outputs.tf
@@ -1,0 +1,19 @@
+output "s3_endpoint_id" {
+  description = "The ID of the S3 Gateway VPC Endpoint (null if disabled)"
+  value       = try(aws_vpc_endpoint.s3[0].id, null)
+}
+
+output "s3_endpoint_prefix_list_id" {
+  description = "The prefix list ID of the S3 endpoint for use in security group rules"
+  value       = try(aws_vpc_endpoint.s3[0].prefix_list_id, null)
+}
+
+output "dynamodb_endpoint_id" {
+  description = "The ID of the DynamoDB Gateway VPC Endpoint (null if disabled)"
+  value       = try(aws_vpc_endpoint.dynamodb[0].id, null)
+}
+
+output "dynamodb_endpoint_prefix_list_id" {
+  description = "The prefix list ID of the DynamoDB endpoint for use in security group rules"
+  value       = try(aws_vpc_endpoint.dynamodb[0].prefix_list_id, null)
+}

--- a/infra/modules/vpc_endpoints/variables.tf
+++ b/infra/modules/vpc_endpoints/variables.tf
@@ -1,0 +1,54 @@
+variable "vpc_id" {
+  description = "The ID of the VPC to create endpoints in"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name used for tagging (e.g., dev, staging, prod)"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "Environment must be one of: dev, staging, prod."
+  }
+}
+
+variable "route_table_ids" {
+  description = "List of route table IDs to associate with Gateway endpoints"
+  type        = list(string)
+
+  validation {
+    condition     = length(var.route_table_ids) > 0
+    error_message = "At least one route table ID must be provided."
+  }
+}
+
+variable "enable_s3_endpoint" {
+  description = "Whether to create an S3 Gateway VPC Endpoint"
+  type        = bool
+  default     = true
+}
+
+variable "enable_dynamodb_endpoint" {
+  description = "Whether to create a DynamoDB Gateway VPC Endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "s3_endpoint_policy" {
+  description = "IAM policy document for the S3 endpoint. If null, allows full S3 access within the VPC."
+  type        = string
+  default     = null
+}
+
+variable "dynamodb_endpoint_policy" {
+  description = "IAM policy document for the DynamoDB endpoint. If null, allows full DynamoDB access within the VPC."
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "Additional tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary
- New `vpc_endpoints` module providing Gateway VPC Endpoints for S3 (enabled by default) and DynamoDB (opt-in)
- Gateway endpoints are free, route traffic over AWS backbone, and eliminate NAT Gateway dependency for S3/DynamoDB access
- Supports custom endpoint policies for least-privilege bucket/table access
- Exports prefix list IDs for use in security group rules

## New Files
- `infra/modules/vpc_endpoints/` — main.tf, variables.tf, outputs.tf, README.md
- `docs/architecture/vpc-endpoints.md` — Mermaid architecture diagram

## Updated Files
- `README.md` — Added to GRID MAP tree and PROGRAM DIRECTORY table
- `CLAUDE.md` — Added to project structure
- `docs/architecture/README.md` — Added to index

## FedRAMP Controls
- SC-7: Boundary protection (traffic stays on AWS private network)
- AC-4: Information flow enforcement (endpoint policies)
- SC-8: Transmission confidentiality (no public internet traversal)

## Test plan
- [ ] Verify module follows CLAUDE.md conventions (variables have descriptions/types/validations)
- [ ] Verify README includes usage examples, inputs/outputs tables
- [ ] Verify architecture diagram renders correctly