### PR TITLE
Fix DynamoDB lock table encryption (#55)

### DIFF
--- a/infra/modules/remote_state/README.md
+++ b/infra/modules/remote_state/README.md
@@ -91,6 +91,7 @@ After applying, copy the `backend_config` output into your `versions.tf` and run
 - **Principal restriction**: Optional deny-all-except policy for named IAM principals
 - **Versioning**: All state files versioned for rollback capability
 - **Public access blocked**: All four public access block settings enabled
+- **DynamoDB encryption at rest**: AWS-managed key by default, or customer-managed KMS key when `kms_key_arn` is provided (FedRAMP SC-28)
 - **Point-in-time recovery**: DynamoDB PITR enabled for lock table disaster recovery
 - **Lifecycle management**: Noncurrent versions expire after configurable days (default 90)
 - **On-demand billing**: DynamoDB uses PAY_PER_REQUEST to avoid over-provisioning

--- a/infra/modules/remote_state/main.tf
+++ b/infra/modules/remote_state/main.tf
@@ -144,6 +144,11 @@ resource "aws_dynamodb_table" "lock" {
     enabled = true
   }
 
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = var.kms_key_arn
+  }
+
   tags = merge(var.tags, {
     Name        = var.lock_table_name
     Environment = var.environment


### PR DESCRIPTION
## Summary
- Add `server_side_encryption` block to DynamoDB state lock table with configurable KMS key
- Add `kms_key_arn` variable for customer-managed key support (defaults to AWS-managed encryption)
- Addresses FedRAMP SC-28 (Protection of Information at Rest)

Closes #55

## Test plan
- [ ] `tofu validate` passes on remote_state module
- [ ] `tofu plan` shows encryption block added to DynamoDB table
- [ ] Verify KMS key ARN is optional (null = AWS-managed encryption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)