### PR TITLE
Add ALB target_protocol variable (#57)

### DIFF
--- a/infra/modules/alb/README.md
+++ b/infra/modules/alb/README.md
@@ -62,6 +62,7 @@ When a `certificate_arn` is provided, the HTTP listener automatically redirects 
 | `enable_deletion_protection`      | `bool`         | `false`                                  | no       | Prevent accidental ALB deletion             |
 | `idle_timeout`                    | `number`       | `60`                                     | no       | Idle connection timeout in seconds (1-4000) |
 | `target_port`                     | `number`       | `80`                                     | no       | Port targets listen on                      |
+| `target_protocol`                 | `string`       | `HTTP`                                   | no       | Target group and health check protocol      |
 | `target_type`                     | `string`       | `ip`                                     | no       | Target type (instance, ip, lambda, alb)     |
 | `deregistration_delay`            | `number`       | `30`                                     | no       | Seconds before deregistering targets (0-3600)|
 | `certificate_arn`                 | `string`       | `null`                                   | no       | ACM certificate ARN for HTTPS               |

--- a/infra/modules/alb/main.tf
+++ b/infra/modules/alb/main.tf
@@ -36,7 +36,7 @@ resource "aws_lb" "this" {
 resource "aws_lb_target_group" "default" {
   name                 = "${var.environment}-${var.name}-default"
   port                 = var.target_port
-  protocol             = "HTTP"
+  protocol             = var.target_protocol
   vpc_id               = var.vpc_id
   target_type          = var.target_type
   deregistration_delay = var.deregistration_delay
@@ -48,7 +48,7 @@ resource "aws_lb_target_group" "default" {
     interval            = var.health_check_interval
     path                = var.health_check_path
     port                = "traffic-port"
-    protocol            = "HTTP"
+    protocol            = var.target_protocol
     timeout             = var.health_check_timeout
     matcher             = var.health_check_matcher
   }

--- a/infra/modules/alb/variables.tf
+++ b/infra/modules/alb/variables.tf
@@ -78,6 +78,17 @@ variable "target_port" {
   }
 }
 
+variable "target_protocol" {
+  description = "Protocol for the default target group and health check (HTTP or HTTPS)"
+  type        = string
+  default     = "HTTP"
+
+  validation {
+    condition     = contains(["HTTP", "HTTPS"], var.target_protocol)
+    error_message = "Target protocol must be one of: HTTP, HTTPS."
+  }
+}
+
 variable "target_type" {
   description = "Type of target (instance, ip, lambda, alb)"
   type        = string


### PR DESCRIPTION
## Summary
- Add `target_protocol` variable to ALB module (default: HTTP, supports HTTP/HTTPS)
- Replace hardcoded `protocol = "HTTP"` in target group and health check with variable
- Enables end-to-end encryption when backends support HTTPS
- Addresses FedRAMP SC-8 (Transmission Confidentiality and Integrity)

Closes #57

## Test plan
- [ ] `tofu validate` passes on alb module
- [ ] `tofu plan` shows no changes when target_protocol defaults to HTTP
- [ ] Verify validation rejects invalid protocol values
- [ ] Verify health check protocol matches target protocol

🤖 Generated with [Claude Code](https://claude.com/claude-code)