### PR TITLE
Add multi-AZ NAT Gateway and configurable public IP (#54, #58)

### DIFF
--- a/infra/modules/vpc/README.md
+++ b/infra/modules/vpc/README.md
@@ -1,6 +1,6 @@
 # VPC Module
 
-Creates an AWS VPC with public and private subnets across multiple availability zones, an Internet Gateway, an optional NAT Gateway, and optional VPC Flow Logs. Default VPC resources (security group, network ACL, route table) are managed with deny-all rules for security hardening.
+Creates an AWS VPC with public and private subnets across multiple availability zones, an Internet Gateway, an optional NAT Gateway (single or per-AZ for high availability), and optional VPC Flow Logs. Default VPC resources (security group, network ACL, route table) are managed with deny-all rules for security hardening.
 
 ## Usage
 
@@ -11,7 +11,8 @@ module "vpc" {
   cidr_block         = "10.0.0.0/16"
   environment        = "dev"
   availability_zones = ["us-east-1a", "us-east-1b", "us-east-1c"]
-  enable_nat_gateway = false
+  enable_nat_gateway = true
+  single_nat_gateway = true
   enable_flow_logs   = true
 
   public_subnet_cidrs = [
@@ -32,33 +33,65 @@ module "vpc" {
 }
 ```
 
+## NAT Gateway: High Availability vs Cost
+
+The module supports two NAT Gateway deployment modes controlled by the `single_nat_gateway` variable:
+
+| Mode | `single_nat_gateway` | NAT Gateways | EIPs | Private Route Tables | Cost | Availability |
+| --- | --- | --- | --- | --- | --- | --- |
+| Single (default) | `true` | 1 | 1 | 1 | Lower | Single AZ failure risk |
+| Multi-AZ HA | `false` | 1 per AZ | 1 per AZ | 1 per AZ | Higher | Resilient to AZ failure |
+
+**Single NAT Gateway** (default): All private subnets route outbound traffic through a single NAT Gateway in the first AZ. This is cost-effective for development and staging environments but creates a single point of failure -- if the NAT Gateway's AZ goes down, all private subnet outbound traffic fails.
+
+**Multi-AZ NAT Gateway**: Each AZ gets its own NAT Gateway, EIP, and private route table. Each private subnet routes through the NAT Gateway in its own AZ. This provides high availability and is recommended for production workloads. Cross-AZ data transfer costs are also reduced since traffic stays within the same AZ.
+
+```hcl
+# Production: HA NAT Gateway (one per AZ)
+module "vpc" {
+  source = "git::https://github.com/jsandov/cloud-voyager-infra.git//infra/modules/vpc?ref=v2.0.0"
+
+  cidr_block         = "10.0.0.0/16"
+  environment        = "prod"
+  availability_zones = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  enable_nat_gateway = true
+  single_nat_gateway = false
+
+  public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  private_subnet_cidrs = ["10.0.11.0/24", "10.0.12.0/24", "10.0.13.0/24"]
+}
+```
+
 ## Inputs
 
-| Name                      | Type           | Default | Required | Description                                              |
-| ------------------------- | -------------- | ------- | -------- | -------------------------------------------------------- |
-| `cidr_block`              | `string`       | ---       | yes      | The CIDR block for the VPC                               |
-| `environment`             | `string`       | ---       | yes      | Environment name for tagging (dev, staging, prod)        |
-| `public_subnet_cidrs`     | `list(string)` | ---       | yes      | CIDR blocks for public subnets (one per AZ)              |
-| `private_subnet_cidrs`    | `list(string)` | ---       | yes      | CIDR blocks for private subnets (one per AZ)             |
-| `availability_zones`      | `list(string)` | ---       | yes      | AWS availability zones to deploy subnets into            |
-| `enable_nat_gateway`      | `bool`         | `false` | no       | Whether to create a NAT Gateway for private subnets      |
-| `enable_flow_logs`        | `bool`         | `true`  | no       | Whether to enable VPC Flow Logs                          |
-| `flow_log_retention_days` | `number`       | `30`    | no       | Days to retain flow logs in CloudWatch                   |
-| `flow_log_kms_key_arn`    | `string`       | `null`  | no       | KMS key ARN for encrypting VPC Flow Logs                 |
-| `tags`                    | `map(string)`  | `{}`    | no       | Additional tags to apply to all resources                |
+| Name                      | Type           | Default | Required | Description                                                                          |
+| ------------------------- | -------------- | ------- | -------- | ------------------------------------------------------------------------------------ |
+| `cidr_block`              | `string`       | ---     | yes      | The CIDR block for the VPC                                                           |
+| `environment`             | `string`       | ---     | yes      | Environment name for tagging (dev, staging, prod)                                    |
+| `public_subnet_cidrs`     | `list(string)` | ---     | yes      | CIDR blocks for public subnets (one per AZ)                                          |
+| `private_subnet_cidrs`    | `list(string)` | ---     | yes      | CIDR blocks for private subnets (one per AZ)                                         |
+| `availability_zones`      | `list(string)` | ---     | yes      | AWS availability zones to deploy subnets into                                        |
+| `enable_nat_gateway`      | `bool`         | `false` | no       | Whether to create a NAT Gateway for private subnets                                  |
+| `single_nat_gateway`      | `bool`         | `true`  | no       | Use a single NAT Gateway (true) or one per AZ for HA (false)                         |
+| `map_public_ip_on_launch` | `bool`         | `true`  | no       | Whether instances launched in public subnets receive a public IP address              |
+| `enable_flow_logs`        | `bool`         | `true`  | no       | Whether to enable VPC Flow Logs                                                      |
+| `flow_log_retention_days` | `number`       | `30`    | no       | Days to retain flow logs in CloudWatch                                               |
+| `flow_log_kms_key_arn`    | `string`       | `null`  | no       | KMS key ARN for encrypting VPC Flow Logs                                             |
+| `tags`                    | `map(string)`  | `{}`    | no       | Additional tags to apply to all resources                                            |
 
 ## Outputs
 
-| Name                        | Description                                        |
-| --------------------------- | -------------------------------------------------- |
-| `vpc_id`                    | The ID of the VPC                                  |
-| `vpc_cidr_block`            | The CIDR block of the VPC                          |
-| `public_subnet_ids`         | List of public subnet IDs                          |
-| `private_subnet_ids`        | List of private subnet IDs                         |
-| `internet_gateway_id`       | The ID of the Internet Gateway                     |
-| `nat_gateway_ids`           | List of NAT Gateway IDs (empty if NAT is disabled) |
-| `public_route_table_id`     | The ID of the public route table                   |
-| `private_route_table_id`    | The ID of the private route table                  |
-| `default_security_group_id` | The ID of the default security group (deny-all)    |
-| `flow_log_id`               | The ID of the VPC Flow Log (null if disabled)      |
-| `flow_log_group_name`       | CloudWatch Log Group name for flow logs            |
+| Name                        | Description                                                              |
+| --------------------------- | ------------------------------------------------------------------------ |
+| `vpc_id`                    | The ID of the VPC                                                        |
+| `vpc_cidr_block`            | The CIDR block of the VPC                                                |
+| `public_subnet_ids`         | List of public subnet IDs                                                |
+| `private_subnet_ids`        | List of private subnet IDs                                               |
+| `internet_gateway_id`       | The ID of the Internet Gateway                                           |
+| `nat_gateway_ids`           | List of NAT Gateway IDs (empty if NAT is disabled)                       |
+| `public_route_table_id`     | The ID of the public route table                                         |
+| `private_route_table_id`    | The ID of the first private route table (for backward compatibility)     |
+| `private_route_table_ids`   | List of all private route table IDs (one per AZ when HA NAT is enabled)  |
+| `default_security_group_id` | The ID of the default security group (deny-all)                          |
+| `flow_log_id`               | The ID of the VPC Flow Log (null if disabled)                            |
+| `flow_log_group_name`       | CloudWatch Log Group name for flow logs                                  |

--- a/infra/modules/vpc/outputs.tf
+++ b/infra/modules/vpc/outputs.tf
@@ -34,8 +34,13 @@ output "public_route_table_id" {
 }
 
 output "private_route_table_id" {
-  description = "The ID of the private route table"
-  value       = aws_route_table.private.id
+  description = "The ID of the first private route table (for backward compatibility)"
+  value       = aws_route_table.private[0].id
+}
+
+output "private_route_table_ids" {
+  description = "List of private route table IDs (one per AZ when single_nat_gateway is false)"
+  value       = aws_route_table.private[*].id
 }
 
 output "default_security_group_id" {

--- a/infra/modules/vpc/variables.tf
+++ b/infra/modules/vpc/variables.tf
@@ -54,6 +54,18 @@ variable "enable_nat_gateway" {
   default     = false
 }
 
+variable "single_nat_gateway" {
+  description = "Whether to provision a single shared NAT Gateway (true) or one NAT Gateway per AZ for high availability (false)"
+  type        = bool
+  default     = true
+}
+
+variable "map_public_ip_on_launch" {
+  description = "Whether instances launched in public subnets receive a public IP address"
+  type        = bool
+  default     = true
+}
+
 variable "enable_flow_logs" {
   description = "Whether to enable VPC Flow Logs for network traffic monitoring"
   type        = bool


### PR DESCRIPTION
## Summary
- Add `single_nat_gateway` variable: `true` (default) for single NAT GW, `false` for one per AZ
- Multi-AZ mode creates dedicated NAT Gateway, EIP, and private route table per AZ
- Add `map_public_ip_on_launch` variable to replace hardcoded `true` value
- Add `private_route_table_ids` output for per-AZ route table consumers
- Update README with HA NAT documentation, comparison table, and production example
- Addresses FedRAMP REL-02 (High Availability) and SEC-05 (Network Hardening)

Closes #54, closes #58

## Test plan
- [ ] `tofu validate` passes on vpc module
- [ ] `tofu plan` with `single_nat_gateway = true` shows single NAT (backward compatible)
- [ ] `tofu plan` with `single_nat_gateway = false` shows per-AZ NAT resources
- [ ] Verify `map_public_ip_on_launch = false` removes auto-assign public IP
- [ ] Verify `private_route_table_ids` output includes all per-AZ route tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)