### PR TITLE
Add FedRAMP-compliant MCP server module

### DIFF
--- a/infra/modules/mcp_server/README.md
+++ b/infra/modules/mcp_server/README.md
@@ -1,0 +1,249 @@
+# MCP Server Module
+
+A production-ready, FedRAMP-compliant OpenTofu module that deploys a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server on AWS Lambda behind API Gateway v2. Designed for secure, scalable AI tool serving with built-in authentication, encryption, and continuous monitoring.
+
+## Architecture
+
+```
+MCP Client (Claude Code, Cursor, etc.)
+    |  HTTPS POST/GET/DELETE /mcp (JSON-RPC 2.0)
+    v
++-------------------+
+| WAF v2 (optional) |  Rate limiting + IP filtering (SC-7)
++-------------------+
+    |
+    v
++---------------------------+
+| API Gateway v2 HTTP API   |
+|  - Cognito JWT Auth (IA-2)|  
+|  - Access logging (AU-2)  |  
+|  - Throttling (CM-7)      |  
+|  - CORS: Mcp-Session-Id   |
++---------------------------+
+    |
+    v
++---------------------------+
+| Lambda Function           |
+|  - Container image        |
+|  - VPC private subnets    |
+|  - KMS-encrypted env (SC-28)
+|  - X-Ray tracing (SI-4)  |
+|  - Reserved concurrency   |
++---------------------------+
+    |
+    +---> CloudWatch Logs (KMS-encrypted, AU-2/AU-3)
+    +---> CloudWatch Alarms --> SNS (SI-4, IR-4)
+    +---> DynamoDB Sessions (optional, KMS-encrypted)
+```
+
+## Usage
+
+### Minimal Configuration
+
+```hcl
+module "mcp_server" {
+  source = "git::https://github.com/jsandov/cloud-voyager-infra.git//infra/modules/mcp_server?ref=v1.0.0"
+
+  name        = "my-tools"
+  environment = "dev"
+  image_uri   = "123456789012.dkr.ecr.us-east-1.amazonaws.com/mcp-server:latest"
+
+  vpc_id                 = module.vpc.vpc_id
+  vpc_subnet_ids         = module.vpc.private_subnet_ids
+  vpc_security_group_ids = [module.vpc.lambda_security_group_id]
+
+  kms_key_arn = module.kms.key_arn
+
+  # Disable auth for local development
+  enable_auth = false
+}
+```
+
+### Production Configuration
+
+```hcl
+module "mcp_server" {
+  source = "git::https://github.com/jsandov/cloud-voyager-infra.git//infra/modules/mcp_server?ref=v1.0.0"
+
+  name        = "ai-tools"
+  environment = "prod"
+  image_uri   = "123456789012.dkr.ecr.us-east-1.amazonaws.com/mcp-server:v2.1.0"
+
+  # Compute
+  memory_size                    = 1024
+  timeout                        = 300
+  reserved_concurrent_executions = 50
+  environment_variables = {
+    LOG_LEVEL = "info"
+    REGION    = "us-east-1"
+  }
+
+  # Networking
+  vpc_id                 = module.vpc.vpc_id
+  vpc_subnet_ids         = module.vpc.private_subnet_ids
+  vpc_security_group_ids = [module.vpc.lambda_security_group_id]
+
+  # Encryption
+  kms_key_arn = module.kms.key_arn
+
+  # Auth
+  enable_auth = true
+
+  # API
+  throttle_rate_limit  = 200
+  throttle_burst_limit = 100
+  cors_allowed_origins = ["https://app.example.com"]
+  waf_acl_arn          = module.waf.web_acl_arn
+
+  # Sessions
+  enable_session_table = true
+  session_ttl_seconds  = 7200
+
+  # ECR
+  enable_ecr_repository   = true
+  ecr_image_tag_mutability = "IMMUTABLE"
+  ecr_scan_on_push        = true
+
+  # Observability
+  log_retention_days    = 365
+  enable_xray_tracing   = true
+  alarm_sns_topic_arn   = module.notifications.sns_topic_arn
+  alarm_actions_enabled = true
+
+  tags = {
+    Team    = "platform"
+    CostCenter = "ai-infra"
+  }
+}
+```
+
+## FedRAMP Controls
+
+| Control   | Family                       | Implementation                                                     |
+|-----------|------------------------------|--------------------------------------------------------------------|
+| AC-6      | Access Control               | IAM least-privilege roles; no wildcard actions                     |
+| AU-2/AU-3 | Audit and Accountability     | CloudWatch Logs with structured JSON access logs; KMS encryption   |
+| CM-7      | Configuration Management     | Reserved concurrency limits; API throttling; least functionality   |
+| IA-2/IA-8 | Identification & Auth        | Cognito JWT authorizer with OAuth 2.0 client credentials           |
+| IR-4      | Incident Response            | SNS alarm notifications for automated incident alerting            |
+| SC-7      | Boundary Protection          | VPC private subnets; WAF association; API Gateway as single entry  |
+| SC-8      | Transmission Confidentiality | HTTPS-only API Gateway endpoints; TLS in transit                   |
+| SC-12/13  | Cryptographic Key Management | KMS-managed keys for all encryption operations                     |
+| SC-28     | Protection of Data at Rest   | KMS encryption for Lambda env vars, logs, DynamoDB, and ECR        |
+| SI-4      | System Monitoring            | X-Ray tracing; 5 CloudWatch alarms; structured logging             |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| `name` | Name identifier for the MCP server resources | `string` | n/a | yes |
+| `environment` | Deployment environment (dev, staging, or prod) | `string` | n/a | yes |
+| `tags` | Additional tags to apply to all resources | `map(string)` | `{}` | no |
+| `image_uri` | ECR image URI for the Lambda function container image | `string` | n/a | yes |
+| `memory_size` | Amount of memory in MB allocated to the Lambda function | `number` | `512` | no |
+| `timeout` | Maximum execution time in seconds for the Lambda function | `number` | `180` | no |
+| `reserved_concurrent_executions` | Reserved concurrent executions for the Lambda function (-1 for unreserved) | `number` | `-1` | no |
+| `environment_variables` | Environment variables to pass to the Lambda function | `map(string)` | `{}` | no |
+| `vpc_id` | ID of the VPC where the Lambda function will run | `string` | n/a | yes |
+| `vpc_subnet_ids` | List of private subnet IDs for the Lambda function VPC configuration | `list(string)` | n/a | yes |
+| `vpc_security_group_ids` | List of security group IDs for the Lambda function VPC configuration | `list(string)` | n/a | yes |
+| `kms_key_arn` | ARN of the KMS key used to encrypt environment variables, logs, and data at rest | `string` | n/a | yes |
+| `enable_auth` | Enable Cognito JWT authentication for the API Gateway (FedRAMP IA-2) | `bool` | `true` | no |
+| `throttle_rate_limit` | API Gateway throttle rate limit (requests per second) | `number` | `100` | no |
+| `throttle_burst_limit` | API Gateway throttle burst limit (maximum concurrent requests) | `number` | `50` | no |
+| `cors_allowed_origins` | List of allowed CORS origins for the API Gateway | `list(string)` | `["*"]` | no |
+| `waf_acl_arn` | ARN of the WAF v2 Web ACL to associate with the API Gateway stage | `string` | `null` | no |
+| `enable_session_table` | Enable DynamoDB table for MCP session management | `bool` | `false` | no |
+| `session_ttl_seconds` | TTL in seconds for session records in DynamoDB | `number` | `3600` | no |
+| `enable_ecr_repository` | Enable creation of an ECR repository for the MCP server container image | `bool` | `false` | no |
+| `ecr_image_tag_mutability` | Tag mutability setting for the ECR repository (IMMUTABLE recommended for production) | `string` | `"IMMUTABLE"` | no |
+| `ecr_scan_on_push` | Enable image vulnerability scanning on push to ECR | `bool` | `true` | no |
+| `log_retention_days` | Number of days to retain CloudWatch log events | `number` | `30` | no |
+| `enable_xray_tracing` | Enable AWS X-Ray active tracing for the Lambda function (FedRAMP SI-4) | `bool` | `true` | no |
+| `alarm_sns_topic_arn` | ARN of an existing SNS topic for CloudWatch alarm notifications (creates a new topic if null) | `string` | `null` | no |
+| `alarm_actions_enabled` | Enable alarm actions for CloudWatch metric alarms | `bool` | `true` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `mcp_endpoint_url` | Full URL of the MCP JSON-RPC endpoint (POST/GET/DELETE /mcp) |
+| `api_id` | ID of the API Gateway v2 HTTP API |
+| `api_endpoint` | Base endpoint URL of the API Gateway v2 HTTP API |
+| `lambda_function_arn` | ARN of the MCP server Lambda function |
+| `lambda_function_name` | Name of the MCP server Lambda function |
+| `lambda_role_arn` | ARN of the IAM role used by the Lambda function |
+| `cognito_user_pool_id` | ID of the Cognito user pool (null if auth is disabled) |
+| `cognito_user_pool_endpoint` | Endpoint of the Cognito user pool for JWT token issuance (null if auth is disabled) |
+| `cognito_client_id` | Client ID of the Cognito user pool client (null if auth is disabled) |
+| `ecr_repository_url` | URL of the ECR repository for the MCP server container image (null if ECR is disabled) |
+| `session_table_name` | Name of the DynamoDB session table (null if sessions are disabled) |
+| `log_group_name` | Name of the CloudWatch log group for the Lambda function |
+| `api_log_group_name` | Name of the CloudWatch log group for the API Gateway access logs |
+| `sns_topic_arn` | ARN of the SNS topic used for CloudWatch alarm notifications |
+
+## Authentication
+
+When `enable_auth = true`, the module creates a Cognito user pool with an OAuth 2.0 client credentials flow. To obtain an access token:
+
+```bash
+# Get the client secret from Cognito (or from your secrets manager)
+CLIENT_ID=$(tofu output -raw cognito_client_id)
+CLIENT_SECRET="<retrieve-from-cognito-console-or-secrets-manager>"
+USER_POOL_DOMAIN=$(tofu output -raw cognito_user_pool_endpoint)
+
+# Request an access token using client credentials grant
+TOKEN=$(curl -s -X POST \
+  "https://${USER_POOL_DOMAIN}/oauth2/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&scope=mcp/invoke" \
+  | jq -r '.access_token')
+
+# Call the MCP endpoint
+curl -X POST \
+  "$(tofu output -raw mcp_endpoint_url)" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
+```
+
+## MCP Client Configuration
+
+Configure your MCP client to connect to the deployed server:
+
+```json
+{
+  "mcpServers": {
+    "my-tools": {
+      "url": "https://<api-id>.execute-api.<region>.amazonaws.com/mcp",
+      "headers": {
+        "Authorization": "Bearer <access-token>"
+      }
+    }
+  }
+}
+```
+
+For clients that support OAuth 2.0 natively, configure the Cognito token endpoint directly.
+
+## Design Decisions
+
+- **Container images only**: The module uses `package_type = "Image"` for Lambda to support complex MCP server dependencies and runtimes beyond what ZIP packages offer. This aligns with the MCP specification's recommendation for server-side implementations.
+
+- **VPC required**: Lambda always runs in VPC private subnets to satisfy FedRAMP SC-7 boundary protection requirements. This ensures the function has no direct internet access and all traffic routes through the VPC's network controls.
+
+- **Cognito client credentials flow**: Machine-to-machine authentication via OAuth 2.0 client credentials is used instead of user pool sign-in because MCP clients are automated systems, not interactive users. This satisfies IA-2 and IA-8.
+
+- **Three HTTP routes (POST, GET, DELETE)**: The MCP specification (2025-03-26) defines POST for JSON-RPC requests, GET for SSE-based streaming, and DELETE for session termination. All three routes share the same Lambda integration and authorization configuration.
+
+- **KMS encryption everywhere**: A single KMS key encrypts Lambda environment variables, CloudWatch Logs, DynamoDB (if enabled), ECR (if enabled), and SNS topics. This centralizes key management per SC-12/SC-13.
+
+- **Optional DynamoDB sessions**: Session state is opt-in via `enable_session_table` because not all MCP servers require stateful sessions. When enabled, the table uses PAY_PER_REQUEST billing to avoid capacity planning overhead and includes TTL for automatic cleanup.
+
+- **SNS topic auto-creation**: The module creates an SNS topic for alarms if `alarm_sns_topic_arn` is not provided, allowing standalone deployments. In production, pass an existing topic to consolidate notifications.
+
+- **Immutable ECR tags by default**: `ecr_image_tag_mutability = "IMMUTABLE"` prevents tag overwrites, ensuring deployed image references remain stable and auditable.
+
+- **Structured JSON access logs**: API Gateway access logs use JSON format for easy integration with log analytics tools (CloudWatch Insights, OpenSearch, Splunk) and to satisfy AU-3 content requirements.
+
+- **Alarm thresholds tied to timeout**: The Lambda duration and API Gateway latency alarms use dynamic thresholds (80% and 90% of the configured timeout) so they automatically adjust when timeout values change.

--- a/infra/modules/mcp_server/main.tf
+++ b/infra/modules/mcp_server/main.tf
@@ -1,0 +1,570 @@
+# ---------------------------------------------------------------------------
+# MCP Server Module — main.tf
+# FedRAMP-compliant MCP (Model Context Protocol) server on AWS Lambda
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Locals
+# ---------------------------------------------------------------------------
+
+locals {
+  name_prefix = "${var.environment}-${var.name}"
+
+  default_tags = {
+    Name        = "${local.name_prefix}-mcp"
+    Environment = var.environment
+    ManagedBy   = "opentofu"
+  }
+
+  tags = merge(local.default_tags, var.tags)
+
+  lambda_environment_variables = merge(
+    var.environment_variables,
+    var.enable_session_table ? { SESSION_TABLE_NAME = aws_dynamodb_table.sessions[0].name } : {}
+  )
+
+  alarm_sns_topic_arn = var.alarm_sns_topic_arn != null ? var.alarm_sns_topic_arn : (
+    length(aws_sns_topic.alarms) > 0 ? aws_sns_topic.alarms[0].arn : null
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Data Sources
+# ---------------------------------------------------------------------------
+
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+# ---------------------------------------------------------------------------
+# Authentication — Cognito (IA-2, IA-8)
+# ---------------------------------------------------------------------------
+
+resource "aws_cognito_user_pool" "this" {
+  count = var.enable_auth ? 1 : 0
+
+  name                = "${local.name_prefix}-mcp"
+  deletion_protection = var.environment == "prod" ? "ACTIVE" : "INACTIVE"
+
+  tags = local.tags
+}
+
+resource "aws_cognito_user_pool_domain" "this" {
+  count = var.enable_auth ? 1 : 0
+
+  domain       = "${local.name_prefix}-mcp"
+  user_pool_id = aws_cognito_user_pool.this[0].id
+}
+
+resource "aws_cognito_resource_server" "this" {
+  count = var.enable_auth ? 1 : 0
+
+  identifier   = "mcp"
+  name         = "${local.name_prefix}-mcp-resource-server"
+  user_pool_id = aws_cognito_user_pool.this[0].id
+
+  scope {
+    scope_name        = "invoke"
+    scope_description = "Invoke MCP tools"
+  }
+}
+
+resource "aws_cognito_user_pool_client" "this" {
+  count = var.enable_auth ? 1 : 0
+
+  name                                 = "${local.name_prefix}-mcp-client"
+  user_pool_id                         = aws_cognito_user_pool.this[0].id
+  allowed_oauth_flows                  = ["client_credentials"]
+  generate_secret                      = true
+  allowed_oauth_scopes                 = ["mcp/invoke"]
+  allowed_oauth_flows_user_pool_client = true
+
+  depends_on = [aws_cognito_resource_server.this]
+}
+
+# ---------------------------------------------------------------------------
+# IAM (AC-6)
+# ---------------------------------------------------------------------------
+
+resource "aws_iam_role" "lambda" {
+  name = "${local.name_prefix}-mcp-lambda"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "lambda.amazonaws.com"
+      }
+    }]
+  })
+
+  tags = local.tags
+}
+
+# Basic execution role for CloudWatch Logs access
+resource "aws_iam_role_policy_attachment" "basic_execution" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# VPC access execution role — required because Lambda runs in private subnets
+resource "aws_iam_role_policy_attachment" "vpc_access" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
+# X-Ray tracing permissions (SI-4)
+resource "aws_iam_role_policy_attachment" "xray" {
+  count = var.enable_xray_tracing ? 1 : 0
+
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+}
+
+# KMS access for decrypting environment variables and log groups (SC-12, SC-13)
+resource "aws_iam_role_policy" "kms_access" {
+  name = "${local.name_prefix}-mcp-kms-access"
+  role = aws_iam_role.lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "kms:Decrypt",
+        "kms:DescribeKey",
+        "kms:GenerateDataKey"
+      ]
+      Resource = [var.kms_key_arn]
+    }]
+  })
+}
+
+# DynamoDB access for session management (conditional)
+resource "aws_iam_role_policy" "dynamodb_access" {
+  count = var.enable_session_table ? 1 : 0
+
+  name = "${local.name_prefix}-mcp-dynamodb-access"
+  role = aws_iam_role.lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem",
+        "dynamodb:Query"
+      ]
+      Resource = [aws_dynamodb_table.sessions[0].arn]
+    }]
+  })
+}
+
+# ---------------------------------------------------------------------------
+# CloudWatch Log Groups (AU-2, AU-3)
+# ---------------------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "lambda" {
+  name              = "/aws/lambda/${local.name_prefix}-mcp"
+  retention_in_days = var.log_retention_days
+  kms_key_id        = var.kms_key_arn
+
+  tags = local.tags
+}
+
+resource "aws_cloudwatch_log_group" "api" {
+  name              = "/aws/apigateway/${local.name_prefix}-mcp"
+  retention_in_days = var.log_retention_days
+  kms_key_id        = var.kms_key_arn
+
+  tags = local.tags
+}
+
+# ---------------------------------------------------------------------------
+# Lambda Function (SC-28, CM-7)
+# ---------------------------------------------------------------------------
+
+resource "aws_lambda_function" "this" {
+  function_name = "${local.name_prefix}-mcp"
+  role          = aws_iam_role.lambda.arn
+  package_type  = "Image"
+  image_uri     = var.image_uri
+  memory_size   = var.memory_size
+  timeout       = var.timeout
+  kms_key_arn   = var.kms_key_arn
+
+  reserved_concurrent_executions = var.reserved_concurrent_executions
+
+  vpc_config {
+    subnet_ids         = var.vpc_subnet_ids
+    security_group_ids = var.vpc_security_group_ids
+  }
+
+  tracing_config {
+    mode = var.enable_xray_tracing ? "Active" : "PassThrough"
+  }
+
+  dynamic "environment" {
+    for_each = length(local.lambda_environment_variables) > 0 ? [1] : []
+    content {
+      variables = local.lambda_environment_variables
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.lambda]
+
+  tags = local.tags
+}
+
+# ---------------------------------------------------------------------------
+# API Gateway v2 — HTTP API (SC-7, SC-8)
+# ---------------------------------------------------------------------------
+
+resource "aws_apigatewayv2_api" "this" {
+  name          = "${local.name_prefix}-mcp"
+  protocol_type = "HTTP"
+
+  cors_configuration {
+    allow_origins = var.cors_allowed_origins
+    allow_methods = ["GET", "POST", "DELETE", "OPTIONS"]
+    allow_headers = ["Content-Type", "Authorization", "Mcp-Session-Id"]
+    expose_headers = ["Mcp-Session-Id"]
+    max_age       = 86400
+  }
+
+  tags = local.tags
+}
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.this.id
+  name        = "$default"
+  auto_deploy = true
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.api.arn
+    format = jsonencode({
+      requestId               = "$context.requestId"
+      ip                      = "$context.identity.sourceIp"
+      requestTime             = "$context.requestTime"
+      httpMethod              = "$context.httpMethod"
+      routeKey                = "$context.routeKey"
+      status                  = "$context.status"
+      protocol                = "$context.protocol"
+      responseLength          = "$context.responseLength"
+      integrationErrorMessage = "$context.integrationErrorMessage"
+    })
+  }
+
+  default_route_settings {
+    throttling_rate_limit  = var.throttle_rate_limit
+    throttling_burst_limit = var.throttle_burst_limit
+  }
+
+  tags = local.tags
+}
+
+# Cognito JWT authorizer (IA-2)
+resource "aws_apigatewayv2_authorizer" "cognito" {
+  count = var.enable_auth ? 1 : 0
+
+  api_id           = aws_apigatewayv2_api.this.id
+  authorizer_type  = "JWT"
+  identity_sources = ["$request.header.Authorization"]
+  name             = "${local.name_prefix}-cognito"
+
+  jwt_configuration {
+    issuer   = "https://${aws_cognito_user_pool.this[0].endpoint}"
+    audience = [aws_cognito_user_pool_client.this[0].id]
+  }
+}
+
+# Lambda integration
+resource "aws_apigatewayv2_integration" "lambda" {
+  api_id                 = aws_apigatewayv2_api.this.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.this.invoke_arn
+  payload_format_version = "2.0"
+}
+
+# Route: POST /mcp — primary JSON-RPC endpoint
+resource "aws_apigatewayv2_route" "post_mcp" {
+  api_id    = aws_apigatewayv2_api.this.id
+  route_key = "POST /mcp"
+  target    = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+
+  authorization_type   = var.enable_auth ? "JWT" : "NONE"
+  authorizer_id        = var.enable_auth ? aws_apigatewayv2_authorizer.cognito[0].id : null
+  authorization_scopes = var.enable_auth ? ["mcp/invoke"] : null
+}
+
+# Route: GET /mcp — SSE streaming endpoint
+resource "aws_apigatewayv2_route" "get_mcp" {
+  api_id    = aws_apigatewayv2_api.this.id
+  route_key = "GET /mcp"
+  target    = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+
+  authorization_type   = var.enable_auth ? "JWT" : "NONE"
+  authorizer_id        = var.enable_auth ? aws_apigatewayv2_authorizer.cognito[0].id : null
+  authorization_scopes = var.enable_auth ? ["mcp/invoke"] : null
+}
+
+# Route: DELETE /mcp — session termination endpoint
+resource "aws_apigatewayv2_route" "delete_mcp" {
+  api_id    = aws_apigatewayv2_api.this.id
+  route_key = "DELETE /mcp"
+  target    = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+
+  authorization_type   = var.enable_auth ? "JWT" : "NONE"
+  authorizer_id        = var.enable_auth ? aws_apigatewayv2_authorizer.cognito[0].id : null
+  authorization_scopes = var.enable_auth ? ["mcp/invoke"] : null
+}
+
+# Allow API Gateway to invoke the Lambda function
+resource "aws_lambda_permission" "apigw" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.this.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.this.execution_arn}/*/*/mcp"
+}
+
+# ---------------------------------------------------------------------------
+# WAF v2 Association (SC-7, conditional)
+# ---------------------------------------------------------------------------
+
+resource "aws_wafv2_web_acl_association" "this" {
+  count = var.waf_acl_arn != null ? 1 : 0
+
+  resource_arn = aws_apigatewayv2_stage.default.arn
+  web_acl_arn  = var.waf_acl_arn
+}
+
+# ---------------------------------------------------------------------------
+# ECR Repository (conditional)
+# ---------------------------------------------------------------------------
+
+resource "aws_ecr_repository" "this" {
+  count = var.enable_ecr_repository ? 1 : 0
+
+  name                 = "${local.name_prefix}-mcp"
+  image_tag_mutability = var.ecr_image_tag_mutability
+
+  encryption_configuration {
+    encryption_type = "KMS"
+    kms_key         = var.kms_key_arn
+  }
+
+  image_scanning_configuration {
+    scan_on_push = var.ecr_scan_on_push
+  }
+
+  tags = local.tags
+}
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  count = var.enable_ecr_repository ? 1 : 0
+
+  repository = aws_ecr_repository.this[0].name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep last 10 tagged images"
+        selection = {
+          tagStatus   = "tagged"
+          tagPrefixList = ["v"]
+          countType   = "imageCountMoreThan"
+          countNumber = 10
+        }
+        action = {
+          type = "expire"
+        }
+      },
+      {
+        rulePriority = 2
+        description  = "Expire untagged images after 7 days"
+        selection = {
+          tagStatus  = "untagged"
+          countType  = "sinceImagePushed"
+          countUnit  = "days"
+          countNumber = 7
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}
+
+# ---------------------------------------------------------------------------
+# DynamoDB Sessions Table (conditional)
+# ---------------------------------------------------------------------------
+
+resource "aws_dynamodb_table" "sessions" {
+  count = var.enable_session_table ? 1 : 0
+
+  name         = "${local.name_prefix}-mcp-sessions"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "session_id"
+
+  attribute {
+    name = "session_id"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = var.kms_key_arn
+  }
+
+  tags = local.tags
+}
+
+# ---------------------------------------------------------------------------
+# Monitoring — SNS and CloudWatch Alarms (SI-4, IR-4)
+# ---------------------------------------------------------------------------
+
+resource "aws_sns_topic" "alarms" {
+  count = var.alarm_sns_topic_arn == null ? 1 : 0
+
+  name              = "${local.name_prefix}-mcp-alarms"
+  kms_master_key_id = var.kms_key_arn
+
+  tags = local.tags
+}
+
+# Lambda error rate alarm (SI-4)
+resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
+  alarm_name          = "${local.name_prefix}-mcp-lambda-errors"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "Errors"
+  namespace           = "AWS/Lambda"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 5
+  alarm_description   = "Lambda function error rate exceeded threshold (FedRAMP SI-4)"
+  treat_missing_data  = "notBreaching"
+  actions_enabled     = var.alarm_actions_enabled
+
+  dimensions = {
+    FunctionName = aws_lambda_function.this.function_name
+  }
+
+  alarm_actions = compact([local.alarm_sns_topic_arn])
+  ok_actions    = compact([local.alarm_sns_topic_arn])
+
+  tags = merge(local.tags, { FedRAMP = "SI-4" })
+}
+
+# Lambda duration p99 alarm (SI-4)
+resource "aws_cloudwatch_metric_alarm" "lambda_duration" {
+  alarm_name          = "${local.name_prefix}-mcp-lambda-duration-p99"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "Duration"
+  namespace           = "AWS/Lambda"
+  period              = 300
+  extended_statistic  = "p99"
+  threshold           = var.timeout * 1000 * 0.8
+  alarm_description   = "Lambda p99 duration approaching timeout (FedRAMP SI-4)"
+  treat_missing_data  = "notBreaching"
+  actions_enabled     = var.alarm_actions_enabled
+
+  dimensions = {
+    FunctionName = aws_lambda_function.this.function_name
+  }
+
+  alarm_actions = compact([local.alarm_sns_topic_arn])
+  ok_actions    = compact([local.alarm_sns_topic_arn])
+
+  tags = merge(local.tags, { FedRAMP = "SI-4" })
+}
+
+# Lambda throttle alarm (SI-4, CM-7)
+resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
+  alarm_name          = "${local.name_prefix}-mcp-lambda-throttles"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "Throttles"
+  namespace           = "AWS/Lambda"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 5
+  alarm_description   = "Lambda function throttling detected (FedRAMP SI-4, CM-7)"
+  treat_missing_data  = "notBreaching"
+  actions_enabled     = var.alarm_actions_enabled
+
+  dimensions = {
+    FunctionName = aws_lambda_function.this.function_name
+  }
+
+  alarm_actions = compact([local.alarm_sns_topic_arn])
+  ok_actions    = compact([local.alarm_sns_topic_arn])
+
+  tags = merge(local.tags, { FedRAMP = "SI-4" })
+}
+
+# API Gateway 5xx errors alarm (SI-4)
+resource "aws_cloudwatch_metric_alarm" "api_5xx" {
+  alarm_name          = "${local.name_prefix}-mcp-api-5xx"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "5xx"
+  namespace           = "AWS/ApiGateway"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 10
+  alarm_description   = "API Gateway 5xx error rate exceeded threshold (FedRAMP SI-4)"
+  treat_missing_data  = "notBreaching"
+  actions_enabled     = var.alarm_actions_enabled
+
+  dimensions = {
+    ApiId = aws_apigatewayv2_api.this.id
+  }
+
+  alarm_actions = compact([local.alarm_sns_topic_arn])
+  ok_actions    = compact([local.alarm_sns_topic_arn])
+
+  tags = merge(local.tags, { FedRAMP = "SI-4" })
+}
+
+# API Gateway latency p99 alarm (SI-4)
+resource "aws_cloudwatch_metric_alarm" "api_latency" {
+  alarm_name          = "${local.name_prefix}-mcp-api-latency-p99"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "Latency"
+  namespace           = "AWS/ApiGateway"
+  period              = 300
+  extended_statistic  = "p99"
+  threshold           = var.timeout * 1000 * 0.9
+  alarm_description   = "API Gateway p99 latency approaching timeout (FedRAMP SI-4)"
+  treat_missing_data  = "notBreaching"
+  actions_enabled     = var.alarm_actions_enabled
+
+  dimensions = {
+    ApiId = aws_apigatewayv2_api.this.id
+  }
+
+  alarm_actions = compact([local.alarm_sns_topic_arn])
+  ok_actions    = compact([local.alarm_sns_topic_arn])
+
+  tags = merge(local.tags, { FedRAMP = "SI-4" })
+}

--- a/infra/modules/mcp_server/outputs.tf
+++ b/infra/modules/mcp_server/outputs.tf
@@ -1,0 +1,73 @@
+# ---------------------------------------------------------------------------
+# MCP Server Module — outputs.tf
+# ---------------------------------------------------------------------------
+
+output "mcp_endpoint_url" {
+  description = "Full URL of the MCP JSON-RPC endpoint (POST/GET/DELETE /mcp)"
+  value       = "${aws_apigatewayv2_api.this.api_endpoint}/mcp"
+}
+
+output "api_id" {
+  description = "ID of the API Gateway v2 HTTP API"
+  value       = aws_apigatewayv2_api.this.id
+}
+
+output "api_endpoint" {
+  description = "Base endpoint URL of the API Gateway v2 HTTP API"
+  value       = aws_apigatewayv2_api.this.api_endpoint
+}
+
+output "lambda_function_arn" {
+  description = "ARN of the MCP server Lambda function"
+  value       = aws_lambda_function.this.arn
+}
+
+output "lambda_function_name" {
+  description = "Name of the MCP server Lambda function"
+  value       = aws_lambda_function.this.function_name
+}
+
+output "lambda_role_arn" {
+  description = "ARN of the IAM role used by the Lambda function"
+  value       = aws_iam_role.lambda.arn
+}
+
+output "cognito_user_pool_id" {
+  description = "ID of the Cognito user pool (null if auth is disabled)"
+  value       = try(aws_cognito_user_pool.this[0].id, null)
+}
+
+output "cognito_user_pool_endpoint" {
+  description = "Endpoint of the Cognito user pool for JWT token issuance (null if auth is disabled)"
+  value       = try(aws_cognito_user_pool.this[0].endpoint, null)
+}
+
+output "cognito_client_id" {
+  description = "Client ID of the Cognito user pool client (null if auth is disabled)"
+  value       = try(aws_cognito_user_pool_client.this[0].id, null)
+}
+
+output "ecr_repository_url" {
+  description = "URL of the ECR repository for the MCP server container image (null if ECR is disabled)"
+  value       = try(aws_ecr_repository.this[0].repository_url, null)
+}
+
+output "session_table_name" {
+  description = "Name of the DynamoDB session table (null if sessions are disabled)"
+  value       = try(aws_dynamodb_table.sessions[0].name, null)
+}
+
+output "log_group_name" {
+  description = "Name of the CloudWatch log group for the Lambda function"
+  value       = aws_cloudwatch_log_group.lambda.name
+}
+
+output "api_log_group_name" {
+  description = "Name of the CloudWatch log group for the API Gateway access logs"
+  value       = aws_cloudwatch_log_group.api.name
+}
+
+output "sns_topic_arn" {
+  description = "ARN of the SNS topic used for CloudWatch alarm notifications"
+  value       = local.alarm_sns_topic_arn
+}

--- a/infra/modules/mcp_server/variables.tf
+++ b/infra/modules/mcp_server/variables.tf
@@ -1,0 +1,236 @@
+# ---------------------------------------------------------------------------
+# MCP Server Module — variables.tf
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# General
+# ---------------------------------------------------------------------------
+
+variable "name" {
+  description = "Name identifier for the MCP server resources"
+  type        = string
+
+  validation {
+    condition     = length(var.name) >= 1 && length(var.name) <= 40
+    error_message = "Name must be between 1 and 40 characters."
+  }
+}
+
+variable "environment" {
+  description = "Deployment environment (dev, staging, or prod)"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "Environment must be one of: dev, staging, prod."
+  }
+}
+
+variable "tags" {
+  description = "Additional tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+# ---------------------------------------------------------------------------
+# Compute
+# ---------------------------------------------------------------------------
+
+variable "image_uri" {
+  description = "ECR image URI for the Lambda function container image"
+  type        = string
+}
+
+variable "memory_size" {
+  description = "Amount of memory in MB allocated to the Lambda function"
+  type        = number
+  default     = 512
+
+  validation {
+    condition     = var.memory_size >= 128 && var.memory_size <= 10240
+    error_message = "Memory size must be between 128 and 10240 MB."
+  }
+}
+
+variable "timeout" {
+  description = "Maximum execution time in seconds for the Lambda function"
+  type        = number
+  default     = 180
+
+  validation {
+    condition     = var.timeout >= 1 && var.timeout <= 900
+    error_message = "Timeout must be between 1 and 900 seconds."
+  }
+}
+
+variable "reserved_concurrent_executions" {
+  description = "Reserved concurrent executions for the Lambda function (-1 for unreserved)"
+  type        = number
+  default     = -1
+}
+
+variable "environment_variables" {
+  description = "Environment variables to pass to the Lambda function"
+  type        = map(string)
+  default     = {}
+}
+
+# ---------------------------------------------------------------------------
+# Networking
+# ---------------------------------------------------------------------------
+
+variable "vpc_id" {
+  description = "ID of the VPC where the Lambda function will run"
+  type        = string
+}
+
+variable "vpc_subnet_ids" {
+  description = "List of private subnet IDs for the Lambda function VPC configuration"
+  type        = list(string)
+}
+
+variable "vpc_security_group_ids" {
+  description = "List of security group IDs for the Lambda function VPC configuration"
+  type        = list(string)
+}
+
+# ---------------------------------------------------------------------------
+# Encryption
+# ---------------------------------------------------------------------------
+
+variable "kms_key_arn" {
+  description = "ARN of the KMS key used to encrypt environment variables, logs, and data at rest"
+  type        = string
+}
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+variable "enable_auth" {
+  description = "Enable Cognito JWT authentication for the API Gateway (FedRAMP IA-2)"
+  type        = bool
+  default     = true
+}
+
+# ---------------------------------------------------------------------------
+# API
+# ---------------------------------------------------------------------------
+
+variable "throttle_rate_limit" {
+  description = "API Gateway throttle rate limit (requests per second)"
+  type        = number
+  default     = 100
+
+  validation {
+    condition     = var.throttle_rate_limit >= 1 && var.throttle_rate_limit <= 10000
+    error_message = "Throttle rate limit must be between 1 and 10000."
+  }
+}
+
+variable "throttle_burst_limit" {
+  description = "API Gateway throttle burst limit (maximum concurrent requests)"
+  type        = number
+  default     = 50
+
+  validation {
+    condition     = var.throttle_burst_limit >= 1 && var.throttle_burst_limit <= 5000
+    error_message = "Throttle burst limit must be between 1 and 5000."
+  }
+}
+
+variable "cors_allowed_origins" {
+  description = "List of allowed CORS origins for the API Gateway"
+  type        = list(string)
+  default     = ["*"]
+}
+
+variable "waf_acl_arn" {
+  description = "ARN of the WAF v2 Web ACL to associate with the API Gateway stage"
+  type        = string
+  default     = null
+}
+
+# ---------------------------------------------------------------------------
+# Session
+# ---------------------------------------------------------------------------
+
+variable "enable_session_table" {
+  description = "Enable DynamoDB table for MCP session management"
+  type        = bool
+  default     = false
+}
+
+variable "session_ttl_seconds" {
+  description = "TTL in seconds for session records in DynamoDB"
+  type        = number
+  default     = 3600
+
+  validation {
+    condition     = var.session_ttl_seconds >= 60
+    error_message = "Session TTL must be at least 60 seconds."
+  }
+}
+
+# ---------------------------------------------------------------------------
+# ECR
+# ---------------------------------------------------------------------------
+
+variable "enable_ecr_repository" {
+  description = "Enable creation of an ECR repository for the MCP server container image"
+  type        = bool
+  default     = false
+}
+
+variable "ecr_image_tag_mutability" {
+  description = "Tag mutability setting for the ECR repository (IMMUTABLE recommended for production)"
+  type        = string
+  default     = "IMMUTABLE"
+
+  validation {
+    condition     = contains(["IMMUTABLE", "MUTABLE"], var.ecr_image_tag_mutability)
+    error_message = "ECR image tag mutability must be IMMUTABLE or MUTABLE."
+  }
+}
+
+variable "ecr_scan_on_push" {
+  description = "Enable image vulnerability scanning on push to ECR"
+  type        = bool
+  default     = true
+}
+
+# ---------------------------------------------------------------------------
+# Observability
+# ---------------------------------------------------------------------------
+
+variable "log_retention_days" {
+  description = "Number of days to retain CloudWatch log events"
+  type        = number
+  default     = 30
+
+  validation {
+    condition = contains(
+      [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653],
+      var.log_retention_days
+    )
+    error_message = "Log retention days must be a valid CloudWatch Logs retention value."
+  }
+}
+
+variable "enable_xray_tracing" {
+  description = "Enable AWS X-Ray active tracing for the Lambda function (FedRAMP SI-4)"
+  type        = bool
+  default     = true
+}
+
+variable "alarm_sns_topic_arn" {
+  description = "ARN of an existing SNS topic for CloudWatch alarm notifications (creates a new topic if null)"
+  type        = string
+  default     = null
+}
+
+variable "alarm_actions_enabled" {
+  description = "Enable alarm actions for CloudWatch metric alarms"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## Summary

Production-ready OpenTofu module for deploying MCP (Model Context Protocol) servers on AWS Lambda behind API Gateway v2 with full FedRAMP compliance.

Closes #73

### Resources (~30)
- **Auth**: Cognito User Pool + OAuth 2.0 client_credentials flow
- **IAM**: Least-privilege Lambda execution role (no wildcard actions)
- **Compute**: Container-image Lambda in VPC with X-Ray, KMS, reserved concurrency
- **API**: API Gateway v2 HTTP API with 3 MCP routes (POST/GET/DELETE /mcp), JWT authorizer, throttling
- **Storage**: Optional ECR repository (KMS, immutable tags, scan-on-push) + DynamoDB sessions (TTL, PITR)
- **Observability**: 2 CloudWatch log groups, SNS topic, 5 CloudWatch alarms
- **Security**: WAF association (conditional)

### FedRAMP Controls
SC-7 · SC-8 · SC-12/13 · SC-28 · AC-6 · AU-2/3 · SI-4 · IR-4 · IA-2/8 · CM-7

## Test Plan
- [ ] `tofu fmt -check` passes
- [ ] No wildcard IAM actions in main.tf
- [ ] All variables have description + type + validation
- [ ] All outputs have descriptions
- [ ] README includes usage examples and FedRAMP controls table